### PR TITLE
Fix missing spec in kc-ui deployment.yaml

### DIFF
--- a/kc-ui/templates/deployment.yaml
+++ b/kc-ui/templates/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   name: "kc-ui-deployment"
   labels:
     chart: 'kc-ui-1.0.0'
+spec:
   replicas: 1
   revisionHistoryLimit: 1
   selector:


### PR DESCRIPTION
While working on the gitops layout and starting from the starter template, I discovered that the kc-ui/templates/deployment.yaml was missing the `spec:` line and so was invalid.