### PR TITLE
Update starter-template deployments from latest Helm charts

### DIFF
--- a/environments/dev/env/base/kustomization.yaml
+++ b/environments/dev/env/base/kustomization.yaml
@@ -11,12 +11,6 @@ resources:
   - ./bpm-configmap.yaml
 
 secretGenerator:
-# Empty value for kafka-apikey should be interpreted by consuming microservices
-# that credentials are not required to connect to Kafka.
-# TODO: make this optional
-  - name: eventstreams-apikey
-    literals:
-      - binding=""
   - name: postgresql-url
     literals:
       - binding="jdbc:postgresql://postgresql.postgres.svc:5432/postgres"

--- a/environments/dev/services/fleetms/base/config/deployment.yaml
+++ b/environments/dev/services/fleetms/base/config/deployment.yaml
@@ -3,9 +3,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: "fleetms-deployment"
+  name: "fleet-ms"
   labels:
     chart: 'fleetms-1.0.0'
+    app.kubernetes.io/part-of: refarch-kc
 spec:
   replicas: 1
   revisionHistoryLimit: 1
@@ -36,7 +37,7 @@ spec:
           - name: PORT
             value: "9080"
           - name: APPLICATION_NAME
-            value: "release-name"
+            value: "RELEASE-NAME"
           - name: KAFKA_BROKERS
             valueFrom:
               configMapKeyRef:
@@ -57,8 +58,3 @@ spec:
               configMapKeyRef:
                 name: "kafka-topics"
                 key: bluewaterProblemTopic
-          - name: KAFKA_APIKEY
-            valueFrom:
-              secretKeyRef:
-                name: "eventstreams-apikey"
-                key: binding

--- a/environments/dev/services/fleetms/base/config/route.yaml
+++ b/environments/dev/services/fleetms/base/config/route.yaml
@@ -7,22 +7,12 @@ metadata:
   name: kcontainer-fleetms
   labels:
     chart: 'fleetms-1.0.0'
+    app.kubernetes.io/part-of: refarch-kc
 spec:
-  # Not a required attribute but ArgoCD fails sync without this field included in the YAML
-  # host: kcontainer-fleetms-[project].[cluster-domain]
   path: /
   to:
     kind: Service
-    name: "fleetms-service"
+    name: "fleet-ms"
     weight: 100
   port:
     targetPort: http
-# Not a required attribute but ArgoCD fails sync without this field included in the YAML
-status:
-  ingress:
-  - conditions:
-    - status: "True"
-      type: Admitted
-    # host: kcontainer-fleetms-[project].[cluster-domain]
-    routerName: router
-    wildcardPolicy: None

--- a/environments/dev/services/fleetms/base/config/service.yaml
+++ b/environments/dev/services/fleetms/base/config/service.yaml
@@ -3,14 +3,16 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "fleetms-service"
+  name: "fleet-ms"
   labels:
     chart: "fleetms-1.0.0"
+    app.kubernetes.io/part-of: refarch-kc
 spec:
   type: NodePort
   ports:
   - name: http
     port: 9080
+    nodePort: 31300
   - name: https
     port: 9443
   selector:

--- a/environments/dev/services/kc-ui/base/config/deployment.yaml
+++ b/environments/dev/services/kc-ui/base/config/deployment.yaml
@@ -3,21 +3,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: "kc-ui-deployment"
+  name: "kc-ui"
   labels:
     chart: 'kc-ui-1.0.0'
+    app.kubernetes.io/part-of: refarch-kc
 spec:
   replicas: 1
   revisionHistoryLimit: 1
   selector:
     matchLabels:
-      app: kc-ui
-      release: release-name
+      app: "kc-ui-selector"
   template:
     metadata:
       labels:
-        app: kc-ui
-        release: release-name
+        app: "kc-ui-selector"
+        version: "current"
     spec:
       serviceAccountName: kcontainer-runtime
       containers:
@@ -38,27 +38,27 @@ spec:
             memory: "300Mi"
         env:
           - name: APPLICATION_NAME
-            value: "release-name"
+            value: "RELEASE-NAME"
           - name: PORT
             value : "3010"
           - name: FLEETMS_SERVICE_HOST
-            value: "fleetms-service"
+            value: "fleet-ms"
           - name: FLEETMS_SERVICE_PORT
             value: "9080"
           - name: ORDERCOMMANDMS_SERVICE_HOST
-            value: "ordercommandms-service"
+            value: "order-command-ms"
           - name: ORDERCOMMANDMS_SERVICE_PORT
             value: "9080"
           - name: ORDERQUERYMS_SERVICE_HOST
-            value: "orderqueryms-service"
+            value: "order-query-ms"
           - name: ORDERQUERYMS_SERVICE_PORT
             value: "9080"
           - name: VOYAGESMS_SERVICE_HOST
-            value: "voyagesms-service"
+            value: "voyages-ms"
           - name: VOYAGESMS_SERVICE_PORT
             value: "3000"
           - name: CONTAINERMS_SERVICE_HOST
-            value: "springcontainerms-service"
+            value: "spring-container-ms"
           - name: CONTAINERMS_SERVICE_PORT
             value: "8080"
           - name: KAFKA_BROKERS
@@ -76,8 +76,3 @@ spec:
               configMapKeyRef:
                 name: "kafka-topics"
                 key: bluewaterShipTopic
-          - name: KAFKA_APIKEY
-            valueFrom:
-              secretKeyRef:
-                name: "eventstreams-apikey"
-                key: binding

--- a/environments/dev/services/kc-ui/base/config/route.yaml
+++ b/environments/dev/services/kc-ui/base/config/route.yaml
@@ -7,22 +7,12 @@ metadata:
   name: kcontainer-ui
   labels:
     chart: 'kc-ui-1.0.0'
+    app.kubernetes.io/part-of: refarch-kc
 spec:
-  # Not a required attribute but ArgoCD fails sync without this field included in the YAML
-  # host: kcontainer-ui-[project].[cluster-domain]
   path: /
   to:
     kind: Service
-    name: "kc-ui-service"
+    name: "kc-ui"
     weight: 100
   port:
     targetPort: http
-# Not a required attribute but ArgoCD fails sync without this field included in the YAML
-status:
-  ingress:
-  - conditions:
-    - status: "True"
-      type: Admitted
-    # host: kcontainer-ui-[project].[cluster-domain]
-    routerName: router
-    wildcardPolicy: None

--- a/environments/dev/services/kc-ui/base/config/service.yaml
+++ b/environments/dev/services/kc-ui/base/config/service.yaml
@@ -3,15 +3,16 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "kc-ui-service"
+  name: "kc-ui"
   labels:
     chart: "kc-ui-1.0.0"
+    app.kubernetes.io/part-of: refarch-kc
 spec:
   type: NodePort
   ports:
   - name: http
     protocol: TCP
     port: 3010
+    nodePort: 31010
   selector:
-    app: kc-ui
-    release: release-name
+    app: "kc-ui-selector"

--- a/environments/dev/services/ordercommandms/base/config/deployment.yaml
+++ b/environments/dev/services/ordercommandms/base/config/deployment.yaml
@@ -3,9 +3,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: "ordercommandms-deployment"
+  name: "order-command-ms"
   labels:
     chart: 'ordercommandms-1.0.0'
+    app.kubernetes.io/part-of: refarch-kc
 spec:
   replicas: 1
   revisionHistoryLimit: 1
@@ -38,7 +39,7 @@ spec:
           - name: PORT
             value: "9080"
           - name: APPLICATION_NAME
-            value: "release-name"
+            value: "RELEASE-NAME"
           - name: KAFKA_BROKERS
             valueFrom:
               configMapKeyRef:
@@ -59,8 +60,3 @@ spec:
               configMapKeyRef:
                 name: "kafka-topics"
                 key: errorsTopic
-          - name: KAFKA_APIKEY
-            valueFrom:
-              secretKeyRef:
-                name: "eventstreams-apikey"
-                key: binding

--- a/environments/dev/services/ordercommandms/base/config/route.yaml
+++ b/environments/dev/services/ordercommandms/base/config/route.yaml
@@ -7,22 +7,12 @@ metadata:
   name: kcontainer-order-command
   labels:
     chart: 'ordercommandms-1.0.0'
+    app.kubernetes.io/part-of: refarch-kc
 spec:
-  # Not a required attribute but ArgoCD fails sync without this field included in the YAML
-  # host: kcontainer-order-command-[project].[cluster-domain]
   path: /
   to:
     kind: Service
-    name: "ordercommandms-service"
+    name: "order-command-ms"
     weight: 100
   port:
     targetPort: http
-# Not a required attribute but ArgoCD fails sync without this field included in the YAML
-status:
-  ingress:
-  - conditions:
-    - status: "True"
-      type: Admitted
-    # host: kcontainer-order-command-[project].[cluster-domain]
-    routerName: router
-    wildcardPolicy: None

--- a/environments/dev/services/ordercommandms/base/config/service.yaml
+++ b/environments/dev/services/ordercommandms/base/config/service.yaml
@@ -3,14 +3,16 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "ordercommandms-service"
+  name: "order-command-ms"
   labels:
     chart: "ordercommandms-1.0.0"
+    app.kubernetes.io/part-of: refarch-kc
 spec:
   type: NodePort
   ports:
   - name: http
     port: 9080
+    nodePort: 30201
   - name: https
     port: 9443
   selector:

--- a/environments/dev/services/orderqueryms/base/config/deployment.yaml
+++ b/environments/dev/services/orderqueryms/base/config/deployment.yaml
@@ -3,9 +3,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: "orderqueryms-deployment"
+  name: "order-query-ms"
   labels:
     chart: 'orderqueryms-1.0.0'
+    app.kubernetes.io/part-of: refarch-kc
 spec:
   replicas: 1
   revisionHistoryLimit: 1
@@ -38,7 +39,7 @@ spec:
           - name: PORT
             value: "9080"
           - name: APPLICATION_NAME
-            value: "release-name"
+            value: "RELEASE-NAME"
           - name: KAFKA_BROKERS
             valueFrom:
               configMapKeyRef:
@@ -59,8 +60,3 @@ spec:
               configMapKeyRef:
                 name: "kafka-topics"
                 key: errorsTopic
-          - name: KAFKA_APIKEY
-            valueFrom:
-              secretKeyRef:
-                name: "eventstreams-apikey"
-                key: binding

--- a/environments/dev/services/orderqueryms/base/config/route.yaml
+++ b/environments/dev/services/orderqueryms/base/config/route.yaml
@@ -7,22 +7,12 @@ metadata:
   name: kcontainer-order-query
   labels:
     chart: 'orderqueryms-1.0.0'
+    app.kubernetes.io/part-of: refarch-kc
 spec:
-  # Not a required attribute but ArgoCD fails sync without this field included in the YAML
-  # host: kcontainer-order-query-[project].[cluster-domain]
   path: /
   to:
     kind: Service
-    name: "orderqueryms-service"
+    name: "order-query-ms"
     weight: 100
   port:
     targetPort: http
-# Not a required attribute but ArgoCD fails sync without this field included in the YAML
-status:
-  ingress:
-  - conditions:
-    - status: "True"
-      type: Admitted
-    # host: kcontainer-order-query-[project].[cluster-domain]
-    routerName: router
-    wildcardPolicy: None

--- a/environments/dev/services/orderqueryms/base/config/service.yaml
+++ b/environments/dev/services/orderqueryms/base/config/service.yaml
@@ -3,14 +3,16 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "orderqueryms-service"
+  name: "order-query-ms"
   labels:
     chart: "orderqueryms-1.0.0"
+    app.kubernetes.io/part-of: refarch-kc
 spec:
   type: NodePort
   ports:
   - name: http
     port: 9080
+    nodePort: 31100
   - name: https
     port: 9443
   selector:

--- a/environments/dev/services/reefersimulator/base/config/app-deploy.yaml
+++ b/environments/dev/services/reefersimulator/base/config/app-deploy.yaml
@@ -2,46 +2,55 @@ apiVersion: appsody.dev/v1beta1
 kind: AppsodyApplication
 metadata:
   annotations:
-    commit.image.appsody.dev/author: Jerome Boyer <jerome.boyer@gmail.com>
-    commit.image.appsody.dev/committer: GitHub <noreply@github.com>
-    commit.image.appsody.dev/contextDir: /simulator
-    commit.image.appsody.dev/message: 'Merge pull request #19 from jbcodeforce/master'
-    image.opencontainers.org/revision: bad18355674e29a1b423c06815ae9a503b61ffb7-modified
+    commit.image.appsody.dev/author: Jerome Boyer <boyerje@us.ibm.com>
+    commit.image.appsody.dev/committer: Jerome Boyer <boyerje@us.ibm.com>
+    commit.image.appsody.dev/contextDir: C:\dev\refarch\refarch-reefer-ml\simulator
+    commit.image.appsody.dev/date: Fri May 29 13:02:34 2020 -0500
+    commit.image.appsody.dev/message: scoring prediction bypass (#63)
+    image.opencontainers.org/created: "2020-06-19T17:04:30+01:00"
+    image.opencontainers.org/documentation: https://github.com/ibm-cloud-architecture/refarch-reefer-ml
+    image.opencontainers.org/revision: a199280ba8e998618c2a963463d8339379f16062
+    image.opencontainers.org/source: |
+      https://github.com/ibm-cloud-architecture/refarch-reefer-ml/tree/master
+    image.opencontainers.org/url: https://github.com/ibm-cloud-architecture/refarch-reefer-ml
     stack.appsody.dev/configured: docker.io/appsody/python-flask:0.1
     stack.appsody.dev/created: 2019-11-14T10:29:19+0000
+    stack.appsody.dev/digest: sha256:1405bd0d18b449f90d98ca31ba7c0a53d40dae6e62362a815cedde63bd2a18d2
     stack.appsody.dev/revision: b3e8a19b0a4b66a69daa8d1106f37bbe4167693a
     stack.appsody.dev/tag: appsody/python-flask:0.1.6
   creationTimestamp: null
   labels:
+    app.kubernetes.io/part-of: refarch-kc
     image.opencontainers.org/title: reefer-simulator
     stack.appsody.dev/version: 0.1.6
   name: reefer-simulator
 spec:
-  applicationImage: ibmcase/kcontainer-reefer-simulator-appsody:0.1.46
+  applicationImage: ibmcase/kcontainer-reefer-simulator-appsody:0.1.51
   createKnativeService: false
   env:
   - name: KAFKA_BROKERS
     valueFrom:
       configMapKeyRef:
-        name: kafka-brokers
         key: brokers
+        name: kafka-brokers
   - name: TELEMETRY_TOPIC
     valueFrom:
       configMapKeyRef:
-        name: kafka-topics
         key: reeferTelemetryTopic
+        name: kafka-topics
   - name: CONTAINER_TOPIC
     valueFrom:
       configMapKeyRef:
-        name: kafka-topics
         key: containersTopic
-  - name: KAFKA_APIKEY
-    valueFrom:
-      secretKeyRef:
-        key: binding
-        name: eventstreams-apikey
-  - name: KAFKA_CERT
-    value: /certs/es-cert.pem
+        name: kafka-topics
+# TODO: Remove from app-deploy.yaml in refarch-reefer-ml
+#  - name: KAFKA_APIKEY
+#    valueFrom:
+#      secretKeyRef:
+#        key: binding
+#        name: eventstreams-apikey
+#  - name: KAFKA_CERT
+#    value: /certs/es-cert.pem
   expose: true
   livenessProbe:
     failureThreshold: 12
@@ -60,12 +69,13 @@ spec:
     type: NodePort
   stack: python-flask
   version: 1.0.0
-  volumeMounts:
-  - mountPath: /certs
-    name: eventstreams-cert-pem
-  volumes:
-  - name: eventstreams-cert-pem
-    secret:
-      optional: true
-      secretName: eventstreams-cert-pem
+# TODO: Remove from app-deploy.yaml in refarch-reefer-ml
+#  volumeMounts:
+#  - mountPath: /certs
+#    name: eventstreams-cert-pem
+#  volumes:
+#  - name: eventstreams-cert-pem
+#    secret:
+#      optional: true
+#      secretName: eventstreams-cert-pem
 status: {}

--- a/environments/dev/services/reefersimulator/overlays/kustomization.yaml
+++ b/environments/dev/services/reefersimulator/overlays/kustomization.yaml
@@ -1,5 +1,5 @@
 bases:
   - ../base
 
-#patchesStrategicMerge:
-#  - ./patch.yaml
+patchesStrategicMerge:
+  - ./service-account-patch.yaml

--- a/environments/dev/services/reefersimulator/overlays/service-account-patch.yaml
+++ b/environments/dev/services/reefersimulator/overlays/service-account-patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: appsody.dev/v1beta1
+kind: AppsodyApplication
+metadata:
+  name: reefer-simulator
+spec:
+  serviceAccountName: kcontainer-runtime

--- a/environments/dev/services/scoringmp/base/config/deployment.yaml
+++ b/environments/dev/services/scoringmp/base/config/deployment.yaml
@@ -3,9 +3,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: "scoringmp-deployment"
+  name: "scoring-mp"
   labels:
     chart: 'scoringmp-1.0.0'
+    app.kubernetes.io/part-of: refarch-kc
 spec:
   replicas: 1
   revisionHistoryLimit: 1
@@ -21,13 +22,15 @@ spec:
       serviceAccountName: kcontainer-runtime
       containers:
       - name: "scoringmp"
-        image: "ibmcase/kcontainer-scoringmp-ms:0.1.46"
+        image: "ibmcase/kcontainer-scoringmp-ms:latest"
         imagePullPolicy: Always
+
         readinessProbe:
           httpGet:
             path: /health
             port: 9080
           initialDelaySeconds: 20
+
         resources:
           requests:
             cpu: "200m"
@@ -36,12 +39,12 @@ spec:
           - name: PORT
             value: "9080"
           - name: APPLICATION_NAME
-            value: "scoringmp"
+            value: "RELEASE-NAME"
           ##################################
           ### Predictive model configuration
           ##################################
-          - name: MOCKUP
-            value: "yes"
+          - name: PREDICTIONS_ENABLED
+            value: "false"
           - name: CP4D_BASE_URL
             valueFrom:
               configMapKeyRef:

--- a/environments/dev/services/scoringmp/base/config/route.yaml
+++ b/environments/dev/services/scoringmp/base/config/route.yaml
@@ -7,22 +7,12 @@ metadata:
   name: kcontainer-scoringmp
   labels:
     chart: 'scoringmp-1.0.0'
+    app.kubernetes.io/part-of: refarch-kc
 spec:
-  # Not a required attribute but ArgoCD fails sync without this field included in the YAML
-  # host: kcontainer-scoringmp-[project].[cluster-domain]
   path: /
   to:
     kind: Service
-    name: "scoringmp-service"
+    name: "scoring-mp"
     weight: 100
   port:
     targetPort: http
-# Not a required attribute but ArgoCD fails sync without this field included in the YAML
-status:
-  ingress:
-  - conditions:
-    - status: "True"
-      type: Admitted
-    # host: kcontainer-scoringmp-[project].[cluster-domain]
-    routerName: default
-    wildcardPolicy: None

--- a/environments/dev/services/scoringmp/base/config/service.yaml
+++ b/environments/dev/services/scoringmp/base/config/service.yaml
@@ -3,14 +3,16 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "scoringmp-service"
+  name: "scoring-mp"
   labels:
     chart: "scoringmp-1.0.0"
+    app.kubernetes.io/part-of: refarch-kc
 spec:
   type: NodePort
   ports:
   - name: http
     port: 9080
+    nodePort: 30211
   - name: https
     port: 9443
   selector:

--- a/environments/dev/services/springcontainerms/base/config/deployment.yaml
+++ b/environments/dev/services/springcontainerms/base/config/deployment.yaml
@@ -3,9 +3,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: "springcontainerms-deployment"
+  name: "spring-container-ms"
   labels:
     chart: 'springcontainerms-1.0.0'
+    app.kubernetes.io/part-of: refarch-kc
 spec:
   replicas: 1
   revisionHistoryLimit: 1
@@ -106,18 +107,6 @@ spec:
             value: "ERROR"
           - name: LOGGING_CONTAINER_MS_PRODUCER_CONFIG
             value: "ERROR"
-          - name: KAFKA_APIKEY
-            valueFrom:
-              secretKeyRef:
-                name: "eventstreams-apikey"
-                key: binding
-                optional: true
-          - name: POSTGRESQL_CA_PEM
-            valueFrom:
-              secretKeyRef:
-                name: "postgresql-ca-pem"
-                key: binding
-                optional: true
           - name: POSTGRESQL_URL
             valueFrom:
               secretKeyRef:

--- a/environments/dev/services/springcontainerms/base/config/route.yaml
+++ b/environments/dev/services/springcontainerms/base/config/route.yaml
@@ -7,22 +7,12 @@ metadata:
   name: kcontainer-spring-container
   labels:
     chart: 'springcontainerms-1.0.0'
+    app.kubernetes.io/part-of: refarch-kc
 spec:
-  # Not a required attribute but ArgoCD fails sync without this field included in the YAML
-  # host: kcontainer-spring-container-[project].[cluster-domain]
   path: /
   to:
     kind: Service
-    name: "springcontainerms-service"
+    name: "spring-container-ms"
     weight: 100
   port:
     targetPort: http
-# Not a required attribute but ArgoCD fails sync without this field included in the YAML
-status:
-  ingress:
-  - conditions:
-    - status: "True"
-      type: Admitted
-    # host: kcontainer-spring-container-[project].[cluster-domain]
-    routerName: router
-    wildcardPolicy: None

--- a/environments/dev/services/springcontainerms/base/config/service.yaml
+++ b/environments/dev/services/springcontainerms/base/config/service.yaml
@@ -3,13 +3,15 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "springcontainerms-service"
+  name: "spring-container-ms"
   labels:
     chart: "springcontainerms-1.0.0"
+    app.kubernetes.io/part-of: refarch-kc
 spec:
   type: NodePort
   ports:
   - name: http
     port: 8080
+    nodePort: 31900
   selector:
     app: "springcontainerms-selector"

--- a/environments/dev/services/voyagesms/base/config/deployment.yaml
+++ b/environments/dev/services/voyagesms/base/config/deployment.yaml
@@ -3,9 +3,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: "voyagesms-deployment"
+  name: "voyages-ms"
   labels:
     chart: 'voyagesms-1.0.0'
+    app.kubernetes.io/part-of: refarch-kc
 spec:
   replicas: 1
   strategy:
@@ -44,7 +45,7 @@ spec:
           - name: PORT
             value : "3000"
           - name: APPLICATION_NAME
-            value: "release-name"
+            value: "RELEASE-NAME"
           - name: KAFKA_BROKERS
             valueFrom:
               configMapKeyRef:
@@ -55,8 +56,3 @@ spec:
               configMapKeyRef:
                 name: "kafka-topics"
                 key: ordersTopic
-          - name: KAFKA_APIKEY
-            valueFrom:
-              secretKeyRef:
-                name: "eventstreams-apikey"
-                key: binding

--- a/environments/dev/services/voyagesms/base/config/route.yaml
+++ b/environments/dev/services/voyagesms/base/config/route.yaml
@@ -7,22 +7,12 @@ metadata:
   name: kcontainer-voyagesms
   labels:
     chart: 'voyagesms-1.0.0'
+    app.kubernetes.io/part-of: refarch-kc
 spec:
-  # Not a required attribute but ArgoCD fails sync without this field included in the YAML
-  # host: kcontainer-voyagesms-[project].[cluster-domain]
   path: /
   to:
     kind: Service
-    name: "voyagesms-service"
+    name: "voyages-ms"
     weight: 100
   port:
     targetPort: http
-# Not a required attribute but ArgoCD fails sync without this field included in the YAML
-status:
-  ingress:
-  - conditions:
-    - status: "True"
-      type: Admitted
-    # host: kcontainer-voyagesms-[project].[cluster-domain]
-    routerName: router
-    wildcardPolicy: None

--- a/environments/dev/services/voyagesms/base/config/service.yaml
+++ b/environments/dev/services/voyagesms/base/config/service.yaml
@@ -5,13 +5,15 @@ kind: Service
 metadata:
   annotations:
     prometheus.io/scrape: 'true'
-  name: "voyagesms-service"
+  name: "voyages-ms"
   labels:
     chart: "voyagesms-1.0.0"
+    app.kubernetes.io/part-of: refarch-kc
 spec:
   type: NodePort
   ports:
   - name: http
     port: 3000
+    nodePort: 31000
   selector:
     app: "voyagesms-selector"

--- a/environments/example-credentials/services/fleetms/base/config/deployment.yaml
+++ b/environments/example-credentials/services/fleetms/base/config/deployment.yaml
@@ -3,9 +3,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: "fleetms-deployment"
+  name: "fleet-ms"
   labels:
     chart: 'fleetms-1.0.0'
+    app.kubernetes.io/part-of: refarch-kc
 spec:
   replicas: 1
   revisionHistoryLimit: 1
@@ -36,7 +37,7 @@ spec:
           - name: PORT
             value: "9080"
           - name: APPLICATION_NAME
-            value: "release-name"
+            value: "RELEASE-NAME"
           - name: KAFKA_BROKERS
             valueFrom:
               configMapKeyRef:
@@ -57,8 +58,3 @@ spec:
               configMapKeyRef:
                 name: "kafka-topics"
                 key: bluewaterProblemTopic
-          - name: KAFKA_APIKEY
-            valueFrom:
-              secretKeyRef:
-                name: "eventstreams-apikey"
-                key: binding

--- a/environments/example-credentials/services/fleetms/base/config/route.yaml
+++ b/environments/example-credentials/services/fleetms/base/config/route.yaml
@@ -7,22 +7,12 @@ metadata:
   name: kcontainer-fleetms
   labels:
     chart: 'fleetms-1.0.0'
+    app.kubernetes.io/part-of: refarch-kc
 spec:
-  # Not a required attribute but ArgoCD fails sync without this field included in the YAML
-  # host: kcontainer-fleetms-[project].[cluster-domain]
   path: /
   to:
     kind: Service
-    name: "fleetms-service"
+    name: "fleet-ms"
     weight: 100
   port:
     targetPort: http
-# Not a required attribute but ArgoCD fails sync without this field included in the YAML
-status:
-  ingress:
-  - conditions:
-    - status: "True"
-      type: Admitted
-    # host: kcontainer-fleetms-[project].[cluster-domain]
-    routerName: router
-    wildcardPolicy: None

--- a/environments/example-credentials/services/fleetms/base/config/service.yaml
+++ b/environments/example-credentials/services/fleetms/base/config/service.yaml
@@ -3,14 +3,16 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "fleetms-service"
+  name: "fleet-ms"
   labels:
     chart: "fleetms-1.0.0"
+    app.kubernetes.io/part-of: refarch-kc
 spec:
   type: NodePort
   ports:
   - name: http
     port: 9080
+    nodePort: 31300
   - name: https
     port: 9443
   selector:

--- a/environments/example-credentials/services/fleetms/overlays/es-env.yaml
+++ b/environments/example-credentials/services/fleetms/overlays/es-env.yaml
@@ -1,0 +1,15 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fleet-ms
+spec:
+  template:
+    spec:
+      containers:
+      - name: fleetms
+        env:
+          - name: KAFKA_APIKEY
+            valueFrom:
+              secretKeyRef:
+                name: "eventstreams-apikey"
+                key: binding

--- a/environments/example-credentials/services/fleetms/overlays/kustomization.yaml
+++ b/environments/example-credentials/services/fleetms/overlays/kustomization.yaml
@@ -1,5 +1,5 @@
 bases:
   - ../base
 
-#patchesStrategicMerge:
-#  - ./patch.yaml
+patchesStrategicMerge:
+  - ./es-env.yaml

--- a/environments/example-credentials/services/kc-ui/base/config/deployment.yaml
+++ b/environments/example-credentials/services/kc-ui/base/config/deployment.yaml
@@ -3,21 +3,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: "kc-ui-deployment"
+  name: "kc-ui"
   labels:
     chart: 'kc-ui-1.0.0'
+    app.kubernetes.io/part-of: refarch-kc
 spec:
   replicas: 1
   revisionHistoryLimit: 1
   selector:
     matchLabels:
-      app: kc-ui
-      release: release-name
+      app: "kc-ui-selector"
   template:
     metadata:
       labels:
-        app: kc-ui
-        release: release-name
+        app: "kc-ui-selector"
+        version: "current"
     spec:
       serviceAccountName: kcontainer-runtime
       containers:
@@ -38,27 +38,27 @@ spec:
             memory: "300Mi"
         env:
           - name: APPLICATION_NAME
-            value: "release-name"
+            value: "RELEASE-NAME"
           - name: PORT
             value : "3010"
           - name: FLEETMS_SERVICE_HOST
-            value: "fleetms-service"
+            value: "fleet-ms"
           - name: FLEETMS_SERVICE_PORT
             value: "9080"
           - name: ORDERCOMMANDMS_SERVICE_HOST
-            value: "ordercommandms-service"
+            value: "order-command-ms"
           - name: ORDERCOMMANDMS_SERVICE_PORT
             value: "9080"
           - name: ORDERQUERYMS_SERVICE_HOST
-            value: "orderqueryms-service"
+            value: "order-query-ms"
           - name: ORDERQUERYMS_SERVICE_PORT
             value: "9080"
           - name: VOYAGESMS_SERVICE_HOST
-            value: "voyagesms-service"
+            value: "voyages-ms"
           - name: VOYAGESMS_SERVICE_PORT
             value: "3000"
           - name: CONTAINERMS_SERVICE_HOST
-            value: "springcontainerms-service"
+            value: "spring-container-ms"
           - name: CONTAINERMS_SERVICE_PORT
             value: "8080"
           - name: KAFKA_BROKERS
@@ -76,8 +76,3 @@ spec:
               configMapKeyRef:
                 name: "kafka-topics"
                 key: bluewaterShipTopic
-          - name: KAFKA_APIKEY
-            valueFrom:
-              secretKeyRef:
-                name: "eventstreams-apikey"
-                key: binding

--- a/environments/example-credentials/services/kc-ui/base/config/route.yaml
+++ b/environments/example-credentials/services/kc-ui/base/config/route.yaml
@@ -7,22 +7,12 @@ metadata:
   name: kcontainer-ui
   labels:
     chart: 'kc-ui-1.0.0'
+    app.kubernetes.io/part-of: refarch-kc
 spec:
-  # Not a required attribute but ArgoCD fails sync without this field included in the YAML
-  # host: kcontainer-ui-[project].[cluster-domain]
   path: /
   to:
     kind: Service
-    name: "kc-ui-service"
+    name: "kc-ui"
     weight: 100
   port:
     targetPort: http
-# Not a required attribute but ArgoCD fails sync without this field included in the YAML
-status:
-  ingress:
-  - conditions:
-    - status: "True"
-      type: Admitted
-    # host: kcontainer-ui-[project].[cluster-domain]
-    routerName: router
-    wildcardPolicy: None

--- a/environments/example-credentials/services/kc-ui/base/config/service.yaml
+++ b/environments/example-credentials/services/kc-ui/base/config/service.yaml
@@ -3,15 +3,16 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "kc-ui-service"
+  name: "kc-ui"
   labels:
     chart: "kc-ui-1.0.0"
+    app.kubernetes.io/part-of: refarch-kc
 spec:
   type: NodePort
   ports:
   - name: http
     protocol: TCP
     port: 3010
+    nodePort: 31010
   selector:
-    app: kc-ui
-    release: release-name
+    app: "kc-ui-selector"

--- a/environments/example-credentials/services/kc-ui/overlays/es-env.yaml
+++ b/environments/example-credentials/services/kc-ui/overlays/es-env.yaml
@@ -1,0 +1,15 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kc-ui
+spec:
+  template:
+    spec:
+      containers:
+      - name: kc-ui
+        env:
+          - name: KAFKA_APIKEY
+            valueFrom:
+              secretKeyRef:
+                name: "eventstreams-apikey"
+                key: binding

--- a/environments/example-credentials/services/kc-ui/overlays/kustomization.yaml
+++ b/environments/example-credentials/services/kc-ui/overlays/kustomization.yaml
@@ -1,5 +1,5 @@
 bases:
   - ../base
 
-#patchesStrategicMerge:
-#  - ./patch.yaml
+patchesStrategicMerge:
+  - ./es-env.yaml

--- a/environments/example-credentials/services/ordercommandms/base/config/deployment.yaml
+++ b/environments/example-credentials/services/ordercommandms/base/config/deployment.yaml
@@ -3,9 +3,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: "ordercommandms-deployment"
+  name: "order-command-ms"
   labels:
     chart: 'ordercommandms-1.0.0'
+    app.kubernetes.io/part-of: refarch-kc
 spec:
   replicas: 1
   revisionHistoryLimit: 1
@@ -38,7 +39,7 @@ spec:
           - name: PORT
             value: "9080"
           - name: APPLICATION_NAME
-            value: "release-name"
+            value: "RELEASE-NAME"
           - name: KAFKA_BROKERS
             valueFrom:
               configMapKeyRef:
@@ -59,8 +60,3 @@ spec:
               configMapKeyRef:
                 name: "kafka-topics"
                 key: errorsTopic
-          - name: KAFKA_APIKEY
-            valueFrom:
-              secretKeyRef:
-                name: "eventstreams-apikey"
-                key: binding

--- a/environments/example-credentials/services/ordercommandms/base/config/route.yaml
+++ b/environments/example-credentials/services/ordercommandms/base/config/route.yaml
@@ -7,22 +7,12 @@ metadata:
   name: kcontainer-order-command
   labels:
     chart: 'ordercommandms-1.0.0'
+    app.kubernetes.io/part-of: refarch-kc
 spec:
-  # Not a required attribute but ArgoCD fails sync without this field included in the YAML
-  # host: kcontainer-order-command-[project].[cluster-domain]
   path: /
   to:
     kind: Service
-    name: "ordercommandms-service"
+    name: "order-command-ms"
     weight: 100
   port:
     targetPort: http
-# Not a required attribute but ArgoCD fails sync without this field included in the YAML
-status:
-  ingress:
-  - conditions:
-    - status: "True"
-      type: Admitted
-    # host: kcontainer-order-command-[project].[cluster-domain]
-    routerName: router
-    wildcardPolicy: None

--- a/environments/example-credentials/services/ordercommandms/base/config/service.yaml
+++ b/environments/example-credentials/services/ordercommandms/base/config/service.yaml
@@ -3,14 +3,16 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "ordercommandms-service"
+  name: "order-command-ms"
   labels:
     chart: "ordercommandms-1.0.0"
+    app.kubernetes.io/part-of: refarch-kc
 spec:
   type: NodePort
   ports:
   - name: http
     port: 9080
+    nodePort: 30201
   - name: https
     port: 9443
   selector:

--- a/environments/example-credentials/services/ordercommandms/overlays/es-env.yaml
+++ b/environments/example-credentials/services/ordercommandms/overlays/es-env.yaml
@@ -1,0 +1,15 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: order-command-ms
+spec:
+  template:
+    spec:
+      containers:
+      - name: ordercommandms
+        env:
+          - name: KAFKA_APIKEY
+            valueFrom:
+              secretKeyRef:
+                name: "eventstreams-apikey"
+                key: binding

--- a/environments/example-credentials/services/ordercommandms/overlays/kustomization.yaml
+++ b/environments/example-credentials/services/ordercommandms/overlays/kustomization.yaml
@@ -1,5 +1,5 @@
 bases:
   - ../base
 
-#patchesStrategicMerge:
-#  - ./patch.yaml
+patchesStrategicMerge:
+  - ./es-env.yaml

--- a/environments/example-credentials/services/orderqueryms/base/config/deployment.yaml
+++ b/environments/example-credentials/services/orderqueryms/base/config/deployment.yaml
@@ -3,9 +3,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: "orderqueryms-deployment"
+  name: "order-query-ms"
   labels:
     chart: 'orderqueryms-1.0.0'
+    app.kubernetes.io/part-of: refarch-kc
 spec:
   replicas: 1
   revisionHistoryLimit: 1
@@ -38,7 +39,7 @@ spec:
           - name: PORT
             value: "9080"
           - name: APPLICATION_NAME
-            value: "release-name"
+            value: "RELEASE-NAME"
           - name: KAFKA_BROKERS
             valueFrom:
               configMapKeyRef:
@@ -59,8 +60,3 @@ spec:
               configMapKeyRef:
                 name: "kafka-topics"
                 key: errorsTopic
-          - name: KAFKA_APIKEY
-            valueFrom:
-              secretKeyRef:
-                name: "eventstreams-apikey"
-                key: binding

--- a/environments/example-credentials/services/orderqueryms/base/config/route.yaml
+++ b/environments/example-credentials/services/orderqueryms/base/config/route.yaml
@@ -7,22 +7,12 @@ metadata:
   name: kcontainer-order-query
   labels:
     chart: 'orderqueryms-1.0.0'
+    app.kubernetes.io/part-of: refarch-kc
 spec:
-  # Not a required attribute but ArgoCD fails sync without this field included in the YAML
-  # host: kcontainer-order-query-[project].[cluster-domain]
   path: /
   to:
     kind: Service
-    name: "orderqueryms-service"
+    name: "order-query-ms"
     weight: 100
   port:
     targetPort: http
-# Not a required attribute but ArgoCD fails sync without this field included in the YAML
-status:
-  ingress:
-  - conditions:
-    - status: "True"
-      type: Admitted
-    # host: kcontainer-order-query-[project].[cluster-domain]
-    routerName: router
-    wildcardPolicy: None

--- a/environments/example-credentials/services/orderqueryms/base/config/service.yaml
+++ b/environments/example-credentials/services/orderqueryms/base/config/service.yaml
@@ -3,14 +3,16 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "orderqueryms-service"
+  name: "order-query-ms"
   labels:
     chart: "orderqueryms-1.0.0"
+    app.kubernetes.io/part-of: refarch-kc
 spec:
   type: NodePort
   ports:
   - name: http
     port: 9080
+    nodePort: 31100
   - name: https
     port: 9443
   selector:

--- a/environments/example-credentials/services/orderqueryms/overlays/es-env.yaml
+++ b/environments/example-credentials/services/orderqueryms/overlays/es-env.yaml
@@ -1,0 +1,15 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: order-query-ms
+spec:
+  template:
+    spec:
+      containers:
+      - name: orderqueryms
+        env:
+          - name: KAFKA_APIKEY
+            valueFrom:
+              secretKeyRef:
+                name: "eventstreams-apikey"
+                key: binding

--- a/environments/example-credentials/services/orderqueryms/overlays/kustomization.yaml
+++ b/environments/example-credentials/services/orderqueryms/overlays/kustomization.yaml
@@ -1,5 +1,5 @@
 bases:
   - ../base
 
-#patchesStrategicMerge:
-#  - ./patch.yaml
+patchesStrategicMerge:
+  - ./es-env.yaml

--- a/environments/example-credentials/services/reefersimulator/base/config/app-deploy.yaml
+++ b/environments/example-credentials/services/reefersimulator/base/config/app-deploy.yaml
@@ -2,46 +2,55 @@ apiVersion: appsody.dev/v1beta1
 kind: AppsodyApplication
 metadata:
   annotations:
-    commit.image.appsody.dev/author: Jerome Boyer <jerome.boyer@gmail.com>
-    commit.image.appsody.dev/committer: GitHub <noreply@github.com>
-    commit.image.appsody.dev/contextDir: /simulator
-    commit.image.appsody.dev/message: 'Merge pull request #19 from jbcodeforce/master'
-    image.opencontainers.org/revision: bad18355674e29a1b423c06815ae9a503b61ffb7-modified
+    commit.image.appsody.dev/author: Jerome Boyer <boyerje@us.ibm.com>
+    commit.image.appsody.dev/committer: Jerome Boyer <boyerje@us.ibm.com>
+    commit.image.appsody.dev/contextDir: C:\dev\refarch\refarch-reefer-ml\simulator
+    commit.image.appsody.dev/date: Fri May 29 13:02:34 2020 -0500
+    commit.image.appsody.dev/message: scoring prediction bypass (#63)
+    image.opencontainers.org/created: "2020-06-19T17:04:30+01:00"
+    image.opencontainers.org/documentation: https://github.com/ibm-cloud-architecture/refarch-reefer-ml
+    image.opencontainers.org/revision: a199280ba8e998618c2a963463d8339379f16062
+    image.opencontainers.org/source: |
+      https://github.com/ibm-cloud-architecture/refarch-reefer-ml/tree/master
+    image.opencontainers.org/url: https://github.com/ibm-cloud-architecture/refarch-reefer-ml
     stack.appsody.dev/configured: docker.io/appsody/python-flask:0.1
     stack.appsody.dev/created: 2019-11-14T10:29:19+0000
+    stack.appsody.dev/digest: sha256:1405bd0d18b449f90d98ca31ba7c0a53d40dae6e62362a815cedde63bd2a18d2
     stack.appsody.dev/revision: b3e8a19b0a4b66a69daa8d1106f37bbe4167693a
     stack.appsody.dev/tag: appsody/python-flask:0.1.6
   creationTimestamp: null
   labels:
+    app.kubernetes.io/part-of: refarch-kc
     image.opencontainers.org/title: reefer-simulator
     stack.appsody.dev/version: 0.1.6
   name: reefer-simulator
 spec:
-  applicationImage: ibmcase/kcontainer-reefer-simulator-appsody:0.1.46
+  applicationImage: ibmcase/kcontainer-reefer-simulator-appsody:0.1.51
   createKnativeService: false
   env:
   - name: KAFKA_BROKERS
     valueFrom:
       configMapKeyRef:
-        name: kafka-brokers
         key: brokers
+        name: kafka-brokers
   - name: TELEMETRY_TOPIC
     valueFrom:
       configMapKeyRef:
-        name: kafka-topics
         key: reeferTelemetryTopic
+        name: kafka-topics
   - name: CONTAINER_TOPIC
     valueFrom:
       configMapKeyRef:
-        name: kafka-topics
         key: containersTopic
-  - name: KAFKA_APIKEY
-    valueFrom:
-      secretKeyRef:
-        key: binding
-        name: eventstreams-apikey
-  - name: KAFKA_CERT
-    value: /certs/es-cert.pem
+        name: kafka-topics
+# TODO: Remove from app-deploy.yaml in refarch-reefer-ml
+#  - name: KAFKA_APIKEY
+#    valueFrom:
+#      secretKeyRef:
+#        key: binding
+#        name: eventstreams-apikey
+#  - name: KAFKA_CERT
+#    value: /certs/es-cert.pem
   expose: true
   livenessProbe:
     failureThreshold: 12
@@ -60,12 +69,13 @@ spec:
     type: NodePort
   stack: python-flask
   version: 1.0.0
-  volumeMounts:
-  - mountPath: /certs
-    name: eventstreams-cert-pem
-  volumes:
-  - name: eventstreams-cert-pem
-    secret:
-      optional: true
-      secretName: eventstreams-cert-pem
+# TODO: Remove from app-deploy.yaml in refarch-reefer-ml
+#  volumeMounts:
+#  - mountPath: /certs
+#    name: eventstreams-cert-pem
+#  volumes:
+#  - name: eventstreams-cert-pem
+#    secret:
+#      optional: true
+#      secretName: eventstreams-cert-pem
 status: {}

--- a/environments/example-credentials/services/reefersimulator/overlays/appsody-env-patch.yaml
+++ b/environments/example-credentials/services/reefersimulator/overlays/appsody-env-patch.yaml
@@ -1,0 +1,8 @@
+- op: add
+  path: "/spec/env/-"
+  value:
+    name: KAFKA_APIKEY
+    valueFrom:
+      secretKeyRef:
+        key: binding
+        name: eventstreams-apikey

--- a/environments/example-credentials/services/reefersimulator/overlays/kustomization.yaml
+++ b/environments/example-credentials/services/reefersimulator/overlays/kustomization.yaml
@@ -1,5 +1,13 @@
 bases:
   - ../base
 
-#patchesStrategicMerge:
-#  - ./patch.yaml
+patchesStrategicMerge:
+  - ./service-account-patch.yaml
+
+patchesJson6902:
+  - target:
+      group: appsody.dev
+      version: v1beta1
+      kind: AppsodyApplication
+      name: reefer-simulator
+    path: ./appsody-env-patch.yaml

--- a/environments/example-credentials/services/reefersimulator/overlays/service-account-patch.yaml
+++ b/environments/example-credentials/services/reefersimulator/overlays/service-account-patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: appsody.dev/v1beta1
+kind: AppsodyApplication
+metadata:
+  name: reefer-simulator
+spec:
+  serviceAccountName: kcontainer-runtime

--- a/environments/example-credentials/services/scoringmp/base/config/deployment.yaml
+++ b/environments/example-credentials/services/scoringmp/base/config/deployment.yaml
@@ -3,9 +3,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: "scoringmp-deployment"
+  name: "scoring-mp"
   labels:
     chart: 'scoringmp-1.0.0'
+    app.kubernetes.io/part-of: refarch-kc
 spec:
   replicas: 1
   revisionHistoryLimit: 1
@@ -21,13 +22,15 @@ spec:
       serviceAccountName: kcontainer-runtime
       containers:
       - name: "scoringmp"
-        image: "ibmcase/kcontainer-scoringmp-ms:0.1.46"
+        image: "ibmcase/kcontainer-scoringmp-ms:latest"
         imagePullPolicy: Always
+
         readinessProbe:
           httpGet:
             path: /health
             port: 9080
           initialDelaySeconds: 20
+
         resources:
           requests:
             cpu: "200m"
@@ -36,12 +39,12 @@ spec:
           - name: PORT
             value: "9080"
           - name: APPLICATION_NAME
-            value: "scoringmp"
+            value: "RELEASE-NAME"
           ##################################
           ### Predictive model configuration
           ##################################
-          - name: MOCKUP
-            value: "yes"
+          - name: PREDICTIONS_ENABLED
+            value: "false"
           - name: CP4D_BASE_URL
             valueFrom:
               configMapKeyRef:

--- a/environments/example-credentials/services/scoringmp/base/config/route.yaml
+++ b/environments/example-credentials/services/scoringmp/base/config/route.yaml
@@ -7,22 +7,12 @@ metadata:
   name: kcontainer-scoringmp
   labels:
     chart: 'scoringmp-1.0.0'
+    app.kubernetes.io/part-of: refarch-kc
 spec:
-  # Not a required attribute but ArgoCD fails sync without this field included in the YAML
-  # host: kcontainer-scoringmp-[project].[cluster-domain]
   path: /
   to:
     kind: Service
-    name: "scoringmp-service"
+    name: "scoring-mp"
     weight: 100
   port:
     targetPort: http
-# Not a required attribute but ArgoCD fails sync without this field included in the YAML
-status:
-  ingress:
-  - conditions:
-    - status: "True"
-      type: Admitted
-    # host: kcontainer-scoringmp-[project].[cluster-domain]
-    routerName: default
-    wildcardPolicy: None

--- a/environments/example-credentials/services/scoringmp/base/config/service.yaml
+++ b/environments/example-credentials/services/scoringmp/base/config/service.yaml
@@ -3,14 +3,16 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "scoringmp-service"
+  name: "scoring-mp"
   labels:
     chart: "scoringmp-1.0.0"
+    app.kubernetes.io/part-of: refarch-kc
 spec:
   type: NodePort
   ports:
   - name: http
     port: 9080
+    nodePort: 30211
   - name: https
     port: 9443
   selector:

--- a/environments/example-credentials/services/springcontainerms/base/config/deployment.yaml
+++ b/environments/example-credentials/services/springcontainerms/base/config/deployment.yaml
@@ -3,9 +3,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: "springcontainerms-deployment"
+  name: "spring-container-ms"
   labels:
     chart: 'springcontainerms-1.0.0'
+    app.kubernetes.io/part-of: refarch-kc
 spec:
   replicas: 1
   revisionHistoryLimit: 1
@@ -106,18 +107,6 @@ spec:
             value: "ERROR"
           - name: LOGGING_CONTAINER_MS_PRODUCER_CONFIG
             value: "ERROR"
-          - name: KAFKA_APIKEY
-            valueFrom:
-              secretKeyRef:
-                name: "eventstreams-apikey"
-                key: binding
-                optional: true
-          - name: POSTGRESQL_CA_PEM
-            valueFrom:
-              secretKeyRef:
-                name: "postgresql-ca-pem"
-                key: binding
-                optional: true
           - name: POSTGRESQL_URL
             valueFrom:
               secretKeyRef:

--- a/environments/example-credentials/services/springcontainerms/base/config/route.yaml
+++ b/environments/example-credentials/services/springcontainerms/base/config/route.yaml
@@ -7,22 +7,12 @@ metadata:
   name: kcontainer-spring-container
   labels:
     chart: 'springcontainerms-1.0.0'
+    app.kubernetes.io/part-of: refarch-kc
 spec:
-  # Not a required attribute but ArgoCD fails sync without this field included in the YAML
-  # host: kcontainer-spring-container-[project].[cluster-domain]
   path: /
   to:
     kind: Service
-    name: "springcontainerms-service"
+    name: "spring-container-ms"
     weight: 100
   port:
     targetPort: http
-# Not a required attribute but ArgoCD fails sync without this field included in the YAML
-status:
-  ingress:
-  - conditions:
-    - status: "True"
-      type: Admitted
-    # host: kcontainer-spring-container-[project].[cluster-domain]
-    routerName: router
-    wildcardPolicy: None

--- a/environments/example-credentials/services/springcontainerms/base/config/service.yaml
+++ b/environments/example-credentials/services/springcontainerms/base/config/service.yaml
@@ -3,13 +3,15 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "springcontainerms-service"
+  name: "spring-container-ms"
   labels:
     chart: "springcontainerms-1.0.0"
+    app.kubernetes.io/part-of: refarch-kc
 spec:
   type: NodePort
   ports:
   - name: http
     port: 8080
+    nodePort: 31900
   selector:
     app: "springcontainerms-selector"

--- a/environments/example-credentials/services/springcontainerms/overlays/es-env.yaml
+++ b/environments/example-credentials/services/springcontainerms/overlays/es-env.yaml
@@ -13,8 +13,3 @@ spec:
               secretKeyRef:
                 name: "eventstreams-apikey"
                 key: binding
-          - name: POSTGRESQL_CA_PEM
-            valueFrom:
-              secretKeyRef:
-                name: "postgresql-ca-pem"
-                key: binding

--- a/environments/example-credentials/services/springcontainerms/overlays/es-env.yaml
+++ b/environments/example-credentials/services/springcontainerms/overlays/es-env.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: spring-container-ms
+spec:
+  template:
+    spec:
+      containers:
+      - name: springcontainerms
+        env:
+          - name: KAFKA_APIKEY
+            valueFrom:
+              secretKeyRef:
+                name: "eventstreams-apikey"
+                key: binding
+          - name: POSTGRESQL_CA_PEM
+            valueFrom:
+              secretKeyRef:
+                name: "postgresql-ca-pem"
+                key: binding

--- a/environments/example-credentials/services/springcontainerms/overlays/kustomization.yaml
+++ b/environments/example-credentials/services/springcontainerms/overlays/kustomization.yaml
@@ -3,5 +3,6 @@ bases:
 
 # Postgres CA mounted as /.postgresql/root.crt (for default SSLFactory)
 patchesStrategicMerge:
+  - ./es-env.yaml
   - ./postgres-ca-volume-mount.yaml
   - ./postgres-ca-volume.yaml

--- a/environments/example-credentials/services/springcontainerms/overlays/postgres-ca-volume-mount.yaml
+++ b/environments/example-credentials/services/springcontainerms/overlays/postgres-ca-volume-mount.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: springcontainerms-deployment
+  name: spring-container-ms
 spec:
   template:
     spec:

--- a/environments/example-credentials/services/springcontainerms/overlays/postgres-ca-volume.yaml
+++ b/environments/example-credentials/services/springcontainerms/overlays/postgres-ca-volume.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: springcontainerms-deployment
+  name: spring-container-ms
 spec:
   template:
     spec:

--- a/environments/example-credentials/services/voyagesms/base/config/deployment.yaml
+++ b/environments/example-credentials/services/voyagesms/base/config/deployment.yaml
@@ -3,9 +3,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: "voyagesms-deployment"
+  name: "voyages-ms"
   labels:
     chart: 'voyagesms-1.0.0'
+    app.kubernetes.io/part-of: refarch-kc
 spec:
   replicas: 1
   strategy:
@@ -44,7 +45,7 @@ spec:
           - name: PORT
             value : "3000"
           - name: APPLICATION_NAME
-            value: "release-name"
+            value: "RELEASE-NAME"
           - name: KAFKA_BROKERS
             valueFrom:
               configMapKeyRef:
@@ -55,8 +56,3 @@ spec:
               configMapKeyRef:
                 name: "kafka-topics"
                 key: ordersTopic
-          - name: KAFKA_APIKEY
-            valueFrom:
-              secretKeyRef:
-                name: "eventstreams-apikey"
-                key: binding

--- a/environments/example-credentials/services/voyagesms/base/config/route.yaml
+++ b/environments/example-credentials/services/voyagesms/base/config/route.yaml
@@ -7,22 +7,12 @@ metadata:
   name: kcontainer-voyagesms
   labels:
     chart: 'voyagesms-1.0.0'
+    app.kubernetes.io/part-of: refarch-kc
 spec:
-  # Not a required attribute but ArgoCD fails sync without this field included in the YAML
-  # host: kcontainer-voyagesms-[project].[cluster-domain]
   path: /
   to:
     kind: Service
-    name: "voyagesms-service"
+    name: "voyages-ms"
     weight: 100
   port:
     targetPort: http
-# Not a required attribute but ArgoCD fails sync without this field included in the YAML
-status:
-  ingress:
-  - conditions:
-    - status: "True"
-      type: Admitted
-    # host: kcontainer-voyagesms-[project].[cluster-domain]
-    routerName: router
-    wildcardPolicy: None

--- a/environments/example-credentials/services/voyagesms/base/config/service.yaml
+++ b/environments/example-credentials/services/voyagesms/base/config/service.yaml
@@ -5,13 +5,15 @@ kind: Service
 metadata:
   annotations:
     prometheus.io/scrape: 'true'
-  name: "voyagesms-service"
+  name: "voyages-ms"
   labels:
     chart: "voyagesms-1.0.0"
+    app.kubernetes.io/part-of: refarch-kc
 spec:
   type: NodePort
   ports:
   - name: http
     port: 3000
+    nodePort: 31000
   selector:
     app: "voyagesms-selector"

--- a/environments/example-credentials/services/voyagesms/overlays/es-env.yaml
+++ b/environments/example-credentials/services/voyagesms/overlays/es-env.yaml
@@ -1,0 +1,15 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: voyages-ms
+spec:
+  template:
+    spec:
+      containers:
+      - name: voyagesms
+        env:
+          - name: KAFKA_APIKEY
+            valueFrom:
+              secretKeyRef:
+                name: "eventstreams-apikey"
+                key: binding

--- a/environments/example-credentials/services/voyagesms/overlays/kustomization.yaml
+++ b/environments/example-credentials/services/voyagesms/overlays/kustomization.yaml
@@ -1,5 +1,5 @@
 bases:
   - ../base
 
-#patchesStrategicMerge:
-#  - ./patch.yaml
+patchesStrategicMerge:
+  - ./es-env.yaml

--- a/environments/example-es-truststore/services/fleetms/base/config/deployment.yaml
+++ b/environments/example-es-truststore/services/fleetms/base/config/deployment.yaml
@@ -3,9 +3,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: "fleetms-deployment"
+  name: "fleet-ms"
   labels:
     chart: 'fleetms-1.0.0'
+    app.kubernetes.io/part-of: refarch-kc
 spec:
   replicas: 1
   revisionHistoryLimit: 1
@@ -36,7 +37,7 @@ spec:
           - name: PORT
             value: "9080"
           - name: APPLICATION_NAME
-            value: "release-name"
+            value: "RELEASE-NAME"
           - name: KAFKA_BROKERS
             valueFrom:
               configMapKeyRef:
@@ -57,8 +58,3 @@ spec:
               configMapKeyRef:
                 name: "kafka-topics"
                 key: bluewaterProblemTopic
-          - name: KAFKA_APIKEY
-            valueFrom:
-              secretKeyRef:
-                name: "eventstreams-apikey"
-                key: binding

--- a/environments/example-es-truststore/services/fleetms/base/config/route.yaml
+++ b/environments/example-es-truststore/services/fleetms/base/config/route.yaml
@@ -7,22 +7,12 @@ metadata:
   name: kcontainer-fleetms
   labels:
     chart: 'fleetms-1.0.0'
+    app.kubernetes.io/part-of: refarch-kc
 spec:
-  # Not a required attribute but ArgoCD fails sync without this field included in the YAML
-  # host: kcontainer-fleetms-[project].[cluster-domain]
   path: /
   to:
     kind: Service
-    name: "fleetms-service"
+    name: "fleet-ms"
     weight: 100
   port:
     targetPort: http
-# Not a required attribute but ArgoCD fails sync without this field included in the YAML
-status:
-  ingress:
-  - conditions:
-    - status: "True"
-      type: Admitted
-    # host: kcontainer-fleetms-[project].[cluster-domain]
-    routerName: router
-    wildcardPolicy: None

--- a/environments/example-es-truststore/services/fleetms/base/config/service.yaml
+++ b/environments/example-es-truststore/services/fleetms/base/config/service.yaml
@@ -3,14 +3,16 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "fleetms-service"
+  name: "fleet-ms"
   labels:
     chart: "fleetms-1.0.0"
+    app.kubernetes.io/part-of: refarch-kc
 spec:
   type: NodePort
   ports:
   - name: http
     port: 9080
+    nodePort: 31300
   - name: https
     port: 9443
   selector:

--- a/environments/example-es-truststore/services/fleetms/overlays/es-env.yaml
+++ b/environments/example-es-truststore/services/fleetms/overlays/es-env.yaml
@@ -1,13 +1,18 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: fleetms-deployment
+  name: fleet-ms
 spec:
   template:
     spec:
       containers:
       - name: fleetms
         env:
+          - name: KAFKA_APIKEY
+            valueFrom:
+              secretKeyRef:
+                name: "eventstreams-apikey"
+                key: binding
           - name: TRUSTSTORE_ENABLED
             value: "true"
           - name: TRUSTSTORE_PWD

--- a/environments/example-es-truststore/services/fleetms/overlays/es-volume-mount.yaml
+++ b/environments/example-es-truststore/services/fleetms/overlays/es-volume-mount.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: fleetms-deployment
+  name: fleet-ms
 spec:
   template:
     spec:

--- a/environments/example-es-truststore/services/fleetms/overlays/es-volume.yaml
+++ b/environments/example-es-truststore/services/fleetms/overlays/es-volume.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: fleetms-deployment
+  name: fleet-ms
 spec:
   template:
     spec:

--- a/environments/example-es-truststore/services/kc-ui/base/config/deployment.yaml
+++ b/environments/example-es-truststore/services/kc-ui/base/config/deployment.yaml
@@ -3,21 +3,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: "kc-ui-deployment"
+  name: "kc-ui"
   labels:
     chart: 'kc-ui-1.0.0'
+    app.kubernetes.io/part-of: refarch-kc
 spec:
   replicas: 1
   revisionHistoryLimit: 1
   selector:
     matchLabels:
-      app: kc-ui
-      release: release-name
+      app: "kc-ui-selector"
   template:
     metadata:
       labels:
-        app: kc-ui
-        release: release-name
+        app: "kc-ui-selector"
+        version: "current"
     spec:
       serviceAccountName: kcontainer-runtime
       containers:
@@ -38,27 +38,27 @@ spec:
             memory: "300Mi"
         env:
           - name: APPLICATION_NAME
-            value: "release-name"
+            value: "RELEASE-NAME"
           - name: PORT
             value : "3010"
           - name: FLEETMS_SERVICE_HOST
-            value: "fleetms-service"
+            value: "fleet-ms"
           - name: FLEETMS_SERVICE_PORT
             value: "9080"
           - name: ORDERCOMMANDMS_SERVICE_HOST
-            value: "ordercommandms-service"
+            value: "order-command-ms"
           - name: ORDERCOMMANDMS_SERVICE_PORT
             value: "9080"
           - name: ORDERQUERYMS_SERVICE_HOST
-            value: "orderqueryms-service"
+            value: "order-query-ms"
           - name: ORDERQUERYMS_SERVICE_PORT
             value: "9080"
           - name: VOYAGESMS_SERVICE_HOST
-            value: "voyagesms-service"
+            value: "voyages-ms"
           - name: VOYAGESMS_SERVICE_PORT
             value: "3000"
           - name: CONTAINERMS_SERVICE_HOST
-            value: "springcontainerms-service"
+            value: "spring-container-ms"
           - name: CONTAINERMS_SERVICE_PORT
             value: "8080"
           - name: KAFKA_BROKERS
@@ -76,8 +76,3 @@ spec:
               configMapKeyRef:
                 name: "kafka-topics"
                 key: bluewaterShipTopic
-          - name: KAFKA_APIKEY
-            valueFrom:
-              secretKeyRef:
-                name: "eventstreams-apikey"
-                key: binding

--- a/environments/example-es-truststore/services/kc-ui/base/config/route.yaml
+++ b/environments/example-es-truststore/services/kc-ui/base/config/route.yaml
@@ -7,22 +7,12 @@ metadata:
   name: kcontainer-ui
   labels:
     chart: 'kc-ui-1.0.0'
+    app.kubernetes.io/part-of: refarch-kc
 spec:
-  # Not a required attribute but ArgoCD fails sync without this field included in the YAML
-  # host: kcontainer-ui-[project].[cluster-domain]
   path: /
   to:
     kind: Service
-    name: "kc-ui-service"
+    name: "kc-ui"
     weight: 100
   port:
     targetPort: http
-# Not a required attribute but ArgoCD fails sync without this field included in the YAML
-status:
-  ingress:
-  - conditions:
-    - status: "True"
-      type: Admitted
-    # host: kcontainer-ui-[project].[cluster-domain]
-    routerName: router
-    wildcardPolicy: None

--- a/environments/example-es-truststore/services/kc-ui/base/config/service.yaml
+++ b/environments/example-es-truststore/services/kc-ui/base/config/service.yaml
@@ -3,15 +3,16 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "kc-ui-service"
+  name: "kc-ui"
   labels:
     chart: "kc-ui-1.0.0"
+    app.kubernetes.io/part-of: refarch-kc
 spec:
   type: NodePort
   ports:
   - name: http
     protocol: TCP
     port: 3010
+    nodePort: 31010
   selector:
-    app: kc-ui
-    release: release-name
+    app: "kc-ui-selector"

--- a/environments/example-es-truststore/services/kc-ui/overlays/es-env.yaml
+++ b/environments/example-es-truststore/services/kc-ui/overlays/es-env.yaml
@@ -1,13 +1,18 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: kc-ui-deployment
+  name: kc-ui
 spec:
   template:
     spec:
       containers:
       - name: kc-ui
         env:
+          - name: KAFKA_APIKEY
+            valueFrom:
+              secretKeyRef:
+                name: "eventstreams-apikey"
+                key: binding
           - name: CERTS_ENABLED
             value: "true"
           - name: KAFKA_CERT_PATH

--- a/environments/example-es-truststore/services/kc-ui/overlays/es-volume-mount.yaml
+++ b/environments/example-es-truststore/services/kc-ui/overlays/es-volume-mount.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: kc-ui-deployment
+  name: kc-ui
 spec:
   template:
     spec:

--- a/environments/example-es-truststore/services/kc-ui/overlays/es-volume.yaml
+++ b/environments/example-es-truststore/services/kc-ui/overlays/es-volume.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: kc-ui-deployment
+  name: kc-ui
 spec:
   template:
     spec:

--- a/environments/example-es-truststore/services/ordercommandms/base/config/deployment.yaml
+++ b/environments/example-es-truststore/services/ordercommandms/base/config/deployment.yaml
@@ -3,9 +3,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: "ordercommandms-deployment"
+  name: "order-command-ms"
   labels:
     chart: 'ordercommandms-1.0.0'
+    app.kubernetes.io/part-of: refarch-kc
 spec:
   replicas: 1
   revisionHistoryLimit: 1
@@ -38,7 +39,7 @@ spec:
           - name: PORT
             value: "9080"
           - name: APPLICATION_NAME
-            value: "release-name"
+            value: "RELEASE-NAME"
           - name: KAFKA_BROKERS
             valueFrom:
               configMapKeyRef:
@@ -59,8 +60,3 @@ spec:
               configMapKeyRef:
                 name: "kafka-topics"
                 key: errorsTopic
-          - name: KAFKA_APIKEY
-            valueFrom:
-              secretKeyRef:
-                name: "eventstreams-apikey"
-                key: binding

--- a/environments/example-es-truststore/services/ordercommandms/base/config/route.yaml
+++ b/environments/example-es-truststore/services/ordercommandms/base/config/route.yaml
@@ -7,22 +7,12 @@ metadata:
   name: kcontainer-order-command
   labels:
     chart: 'ordercommandms-1.0.0'
+    app.kubernetes.io/part-of: refarch-kc
 spec:
-  # Not a required attribute but ArgoCD fails sync without this field included in the YAML
-  # host: kcontainer-order-command-[project].[cluster-domain]
   path: /
   to:
     kind: Service
-    name: "ordercommandms-service"
+    name: "order-command-ms"
     weight: 100
   port:
     targetPort: http
-# Not a required attribute but ArgoCD fails sync without this field included in the YAML
-status:
-  ingress:
-  - conditions:
-    - status: "True"
-      type: Admitted
-    # host: kcontainer-order-command-[project].[cluster-domain]
-    routerName: router
-    wildcardPolicy: None

--- a/environments/example-es-truststore/services/ordercommandms/base/config/service.yaml
+++ b/environments/example-es-truststore/services/ordercommandms/base/config/service.yaml
@@ -3,14 +3,16 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "ordercommandms-service"
+  name: "order-command-ms"
   labels:
     chart: "ordercommandms-1.0.0"
+    app.kubernetes.io/part-of: refarch-kc
 spec:
   type: NodePort
   ports:
   - name: http
     port: 9080
+    nodePort: 30201
   - name: https
     port: 9443
   selector:

--- a/environments/example-es-truststore/services/ordercommandms/overlays/es-env.yaml
+++ b/environments/example-es-truststore/services/ordercommandms/overlays/es-env.yaml
@@ -1,13 +1,18 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ordercommandms-deployment
+  name: order-command-ms
 spec:
   template:
     spec:
       containers:
       - name: ordercommandms
         env:
+          - name: KAFKA_APIKEY
+            valueFrom:
+              secretKeyRef:
+                name: "eventstreams-apikey"
+                key: binding
           - name: TRUSTSTORE_ENABLED
             value: "true"
           - name: TRUSTSTORE_PWD

--- a/environments/example-es-truststore/services/ordercommandms/overlays/es-volume-mount.yaml
+++ b/environments/example-es-truststore/services/ordercommandms/overlays/es-volume-mount.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ordercommandms-deployment
+  name: order-command-ms
 spec:
   template:
     spec:

--- a/environments/example-es-truststore/services/ordercommandms/overlays/es-volume.yaml
+++ b/environments/example-es-truststore/services/ordercommandms/overlays/es-volume.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ordercommandms-deployment
+  name: order-command-ms
 spec:
   template:
     spec:

--- a/environments/example-es-truststore/services/orderqueryms/base/config/deployment.yaml
+++ b/environments/example-es-truststore/services/orderqueryms/base/config/deployment.yaml
@@ -3,9 +3,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: "orderqueryms-deployment"
+  name: "order-query-ms"
   labels:
     chart: 'orderqueryms-1.0.0'
+    app.kubernetes.io/part-of: refarch-kc
 spec:
   replicas: 1
   revisionHistoryLimit: 1
@@ -38,7 +39,7 @@ spec:
           - name: PORT
             value: "9080"
           - name: APPLICATION_NAME
-            value: "release-name"
+            value: "RELEASE-NAME"
           - name: KAFKA_BROKERS
             valueFrom:
               configMapKeyRef:
@@ -59,8 +60,3 @@ spec:
               configMapKeyRef:
                 name: "kafka-topics"
                 key: errorsTopic
-          - name: KAFKA_APIKEY
-            valueFrom:
-              secretKeyRef:
-                name: "eventstreams-apikey"
-                key: binding

--- a/environments/example-es-truststore/services/orderqueryms/base/config/route.yaml
+++ b/environments/example-es-truststore/services/orderqueryms/base/config/route.yaml
@@ -7,22 +7,12 @@ metadata:
   name: kcontainer-order-query
   labels:
     chart: 'orderqueryms-1.0.0'
+    app.kubernetes.io/part-of: refarch-kc
 spec:
-  # Not a required attribute but ArgoCD fails sync without this field included in the YAML
-  # host: kcontainer-order-query-[project].[cluster-domain]
   path: /
   to:
     kind: Service
-    name: "orderqueryms-service"
+    name: "order-query-ms"
     weight: 100
   port:
     targetPort: http
-# Not a required attribute but ArgoCD fails sync without this field included in the YAML
-status:
-  ingress:
-  - conditions:
-    - status: "True"
-      type: Admitted
-    # host: kcontainer-order-query-[project].[cluster-domain]
-    routerName: router
-    wildcardPolicy: None

--- a/environments/example-es-truststore/services/orderqueryms/base/config/service.yaml
+++ b/environments/example-es-truststore/services/orderqueryms/base/config/service.yaml
@@ -3,14 +3,16 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "orderqueryms-service"
+  name: "order-query-ms"
   labels:
     chart: "orderqueryms-1.0.0"
+    app.kubernetes.io/part-of: refarch-kc
 spec:
   type: NodePort
   ports:
   - name: http
     port: 9080
+    nodePort: 31100
   - name: https
     port: 9443
   selector:

--- a/environments/example-es-truststore/services/orderqueryms/overlays/es-env.yaml
+++ b/environments/example-es-truststore/services/orderqueryms/overlays/es-env.yaml
@@ -1,13 +1,18 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: orderqueryms-deployment
+  name: order-query-ms
 spec:
   template:
     spec:
       containers:
       - name: orderqueryms
         env:
+          - name: KAFKA_APIKEY
+            valueFrom:
+              secretKeyRef:
+                name: "eventstreams-apikey"
+                key: binding
           - name: TRUSTSTORE_ENABLED
             value: "true"
           - name: TRUSTSTORE_PWD

--- a/environments/example-es-truststore/services/orderqueryms/overlays/es-volume-mount.yaml
+++ b/environments/example-es-truststore/services/orderqueryms/overlays/es-volume-mount.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: orderqueryms-deployment
+  name: order-query-ms
 spec:
   template:
     spec:

--- a/environments/example-es-truststore/services/orderqueryms/overlays/es-volume.yaml
+++ b/environments/example-es-truststore/services/orderqueryms/overlays/es-volume.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: orderqueryms-deployment
+  name: order-query-ms
 spec:
   template:
     spec:

--- a/environments/example-es-truststore/services/reefersimulator/base/config/app-deploy.yaml
+++ b/environments/example-es-truststore/services/reefersimulator/base/config/app-deploy.yaml
@@ -2,46 +2,55 @@ apiVersion: appsody.dev/v1beta1
 kind: AppsodyApplication
 metadata:
   annotations:
-    commit.image.appsody.dev/author: Jerome Boyer <jerome.boyer@gmail.com>
-    commit.image.appsody.dev/committer: GitHub <noreply@github.com>
-    commit.image.appsody.dev/contextDir: /simulator
-    commit.image.appsody.dev/message: 'Merge pull request #19 from jbcodeforce/master'
-    image.opencontainers.org/revision: bad18355674e29a1b423c06815ae9a503b61ffb7-modified
+    commit.image.appsody.dev/author: Jerome Boyer <boyerje@us.ibm.com>
+    commit.image.appsody.dev/committer: Jerome Boyer <boyerje@us.ibm.com>
+    commit.image.appsody.dev/contextDir: C:\dev\refarch\refarch-reefer-ml\simulator
+    commit.image.appsody.dev/date: Fri May 29 13:02:34 2020 -0500
+    commit.image.appsody.dev/message: scoring prediction bypass (#63)
+    image.opencontainers.org/created: "2020-06-19T17:04:30+01:00"
+    image.opencontainers.org/documentation: https://github.com/ibm-cloud-architecture/refarch-reefer-ml
+    image.opencontainers.org/revision: a199280ba8e998618c2a963463d8339379f16062
+    image.opencontainers.org/source: |
+      https://github.com/ibm-cloud-architecture/refarch-reefer-ml/tree/master
+    image.opencontainers.org/url: https://github.com/ibm-cloud-architecture/refarch-reefer-ml
     stack.appsody.dev/configured: docker.io/appsody/python-flask:0.1
     stack.appsody.dev/created: 2019-11-14T10:29:19+0000
+    stack.appsody.dev/digest: sha256:1405bd0d18b449f90d98ca31ba7c0a53d40dae6e62362a815cedde63bd2a18d2
     stack.appsody.dev/revision: b3e8a19b0a4b66a69daa8d1106f37bbe4167693a
     stack.appsody.dev/tag: appsody/python-flask:0.1.6
   creationTimestamp: null
   labels:
+    app.kubernetes.io/part-of: refarch-kc
     image.opencontainers.org/title: reefer-simulator
     stack.appsody.dev/version: 0.1.6
   name: reefer-simulator
 spec:
-  applicationImage: ibmcase/kcontainer-reefer-simulator-appsody:0.1.46
+  applicationImage: ibmcase/kcontainer-reefer-simulator-appsody:0.1.51
   createKnativeService: false
   env:
   - name: KAFKA_BROKERS
     valueFrom:
       configMapKeyRef:
-        name: kafka-brokers
         key: brokers
+        name: kafka-brokers
   - name: TELEMETRY_TOPIC
     valueFrom:
       configMapKeyRef:
-        name: kafka-topics
         key: reeferTelemetryTopic
+        name: kafka-topics
   - name: CONTAINER_TOPIC
     valueFrom:
       configMapKeyRef:
-        name: kafka-topics
         key: containersTopic
-  - name: KAFKA_APIKEY
-    valueFrom:
-      secretKeyRef:
-        key: binding
-        name: eventstreams-apikey
-  - name: KAFKA_CERT
-    value: /certs/es-cert.pem
+        name: kafka-topics
+# TODO: Remove from app-deploy.yaml in refarch-reefer-ml
+#  - name: KAFKA_APIKEY
+#    valueFrom:
+#      secretKeyRef:
+#        key: binding
+#        name: eventstreams-apikey
+#  - name: KAFKA_CERT
+#    value: /certs/es-cert.pem
   expose: true
   livenessProbe:
     failureThreshold: 12
@@ -60,12 +69,13 @@ spec:
     type: NodePort
   stack: python-flask
   version: 1.0.0
-  volumeMounts:
-  - mountPath: /certs
-    name: eventstreams-cert-pem
-  volumes:
-  - name: eventstreams-cert-pem
-    secret:
-      optional: true
-      secretName: eventstreams-cert-pem
+# TODO: Remove from app-deploy.yaml in refarch-reefer-ml
+#  volumeMounts:
+#  - mountPath: /certs
+#    name: eventstreams-cert-pem
+#  volumes:
+#  - name: eventstreams-cert-pem
+#    secret:
+#      optional: true
+#      secretName: eventstreams-cert-pem
 status: {}

--- a/environments/example-es-truststore/services/reefersimulator/overlays/appsody-env-patch.yaml
+++ b/environments/example-es-truststore/services/reefersimulator/overlays/appsody-env-patch.yaml
@@ -1,0 +1,13 @@
+- op: add
+  path: "/spec/env/-"
+  value:
+    name: KAFKA_APIKEY
+    valueFrom:
+      secretKeyRef:
+        key: binding
+        name: eventstreams-apikey
+- op: add
+  path: "/spec/env/-"
+  value:
+    name: KAFKA_CERT
+    value: /certs/es-cert.pem

--- a/environments/example-es-truststore/services/reefersimulator/overlays/appsody-volume-mounts.yaml
+++ b/environments/example-es-truststore/services/reefersimulator/overlays/appsody-volume-mounts.yaml
@@ -1,0 +1,8 @@
+apiVersion: appsody.dev/v1beta1
+kind: AppsodyApplication
+metadata:
+  name: reefer-simulator
+spec:
+  volumeMounts:
+  - mountPath: /certs
+    name: eventstreams-cert-pem

--- a/environments/example-es-truststore/services/reefersimulator/overlays/appsody-volumes.yaml
+++ b/environments/example-es-truststore/services/reefersimulator/overlays/appsody-volumes.yaml
@@ -1,0 +1,9 @@
+apiVersion: appsody.dev/v1beta1
+kind: AppsodyApplication
+metadata:
+  name: reefer-simulator
+spec:
+  volumes:
+  - name: eventstreams-cert-pem
+    secret:
+      secretName: es-ca-pemfile

--- a/environments/example-es-truststore/services/reefersimulator/overlays/kustomization.yaml
+++ b/environments/example-es-truststore/services/reefersimulator/overlays/kustomization.yaml
@@ -1,5 +1,17 @@
 bases:
   - ../base
 
-#patchesStrategicMerge:
-#  - ./patch.yaml
+# Event Streams certificate mounted as /certs/es-cert.pem
+
+patchesStrategicMerge:
+  - ./service-account-patch.yaml
+  - ./appsody-volume-mounts.yaml
+  - ./appsody-volumes.yaml
+
+patchesJson6902:
+  - target:
+      group: appsody.dev
+      version: v1beta1
+      kind: AppsodyApplication
+      name: reefer-simulator
+    path: ./appsody-env-patch.yaml

--- a/environments/example-es-truststore/services/reefersimulator/overlays/service-account-patch.yaml
+++ b/environments/example-es-truststore/services/reefersimulator/overlays/service-account-patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: appsody.dev/v1beta1
+kind: AppsodyApplication
+metadata:
+  name: reefer-simulator
+spec:
+  serviceAccountName: kcontainer-runtime

--- a/environments/example-es-truststore/services/scoringmp/base/config/deployment.yaml
+++ b/environments/example-es-truststore/services/scoringmp/base/config/deployment.yaml
@@ -3,9 +3,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: "scoringmp-deployment"
+  name: "scoring-mp"
   labels:
     chart: 'scoringmp-1.0.0'
+    app.kubernetes.io/part-of: refarch-kc
 spec:
   replicas: 1
   revisionHistoryLimit: 1
@@ -21,13 +22,15 @@ spec:
       serviceAccountName: kcontainer-runtime
       containers:
       - name: "scoringmp"
-        image: "ibmcase/kcontainer-scoringmp-ms:0.1.46"
+        image: "ibmcase/kcontainer-scoringmp-ms:latest"
         imagePullPolicy: Always
+
         readinessProbe:
           httpGet:
             path: /health
             port: 9080
           initialDelaySeconds: 20
+
         resources:
           requests:
             cpu: "200m"
@@ -36,12 +39,12 @@ spec:
           - name: PORT
             value: "9080"
           - name: APPLICATION_NAME
-            value: "scoringmp"
+            value: "RELEASE-NAME"
           ##################################
           ### Predictive model configuration
           ##################################
-          - name: MOCKUP
-            value: "yes"
+          - name: PREDICTIONS_ENABLED
+            value: "false"
           - name: CP4D_BASE_URL
             valueFrom:
               configMapKeyRef:

--- a/environments/example-es-truststore/services/scoringmp/base/config/route.yaml
+++ b/environments/example-es-truststore/services/scoringmp/base/config/route.yaml
@@ -7,22 +7,12 @@ metadata:
   name: kcontainer-scoringmp
   labels:
     chart: 'scoringmp-1.0.0'
+    app.kubernetes.io/part-of: refarch-kc
 spec:
-  # Not a required attribute but ArgoCD fails sync without this field included in the YAML
-  # host: kcontainer-scoringmp-[project].[cluster-domain]
   path: /
   to:
     kind: Service
-    name: "scoringmp-service"
+    name: "scoring-mp"
     weight: 100
   port:
     targetPort: http
-# Not a required attribute but ArgoCD fails sync without this field included in the YAML
-status:
-  ingress:
-  - conditions:
-    - status: "True"
-      type: Admitted
-    # host: kcontainer-scoringmp-[project].[cluster-domain]
-    routerName: default
-    wildcardPolicy: None

--- a/environments/example-es-truststore/services/scoringmp/base/config/service.yaml
+++ b/environments/example-es-truststore/services/scoringmp/base/config/service.yaml
@@ -3,14 +3,16 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "scoringmp-service"
+  name: "scoring-mp"
   labels:
     chart: "scoringmp-1.0.0"
+    app.kubernetes.io/part-of: refarch-kc
 spec:
   type: NodePort
   ports:
   - name: http
     port: 9080
+    nodePort: 30211
   - name: https
     port: 9443
   selector:

--- a/environments/example-es-truststore/services/springcontainerms/base/config/deployment.yaml
+++ b/environments/example-es-truststore/services/springcontainerms/base/config/deployment.yaml
@@ -3,9 +3,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: "springcontainerms-deployment"
+  name: "spring-container-ms"
   labels:
     chart: 'springcontainerms-1.0.0'
+    app.kubernetes.io/part-of: refarch-kc
 spec:
   replicas: 1
   revisionHistoryLimit: 1
@@ -106,18 +107,6 @@ spec:
             value: "ERROR"
           - name: LOGGING_CONTAINER_MS_PRODUCER_CONFIG
             value: "ERROR"
-          - name: KAFKA_APIKEY
-            valueFrom:
-              secretKeyRef:
-                name: "eventstreams-apikey"
-                key: binding
-                optional: true
-          - name: POSTGRESQL_CA_PEM
-            valueFrom:
-              secretKeyRef:
-                name: "postgresql-ca-pem"
-                key: binding
-                optional: true
           - name: POSTGRESQL_URL
             valueFrom:
               secretKeyRef:

--- a/environments/example-es-truststore/services/springcontainerms/base/config/route.yaml
+++ b/environments/example-es-truststore/services/springcontainerms/base/config/route.yaml
@@ -7,22 +7,12 @@ metadata:
   name: kcontainer-spring-container
   labels:
     chart: 'springcontainerms-1.0.0'
+    app.kubernetes.io/part-of: refarch-kc
 spec:
-  # Not a required attribute but ArgoCD fails sync without this field included in the YAML
-  # host: kcontainer-spring-container-[project].[cluster-domain]
   path: /
   to:
     kind: Service
-    name: "springcontainerms-service"
+    name: "spring-container-ms"
     weight: 100
   port:
     targetPort: http
-# Not a required attribute but ArgoCD fails sync without this field included in the YAML
-status:
-  ingress:
-  - conditions:
-    - status: "True"
-      type: Admitted
-    # host: kcontainer-spring-container-[project].[cluster-domain]
-    routerName: router
-    wildcardPolicy: None

--- a/environments/example-es-truststore/services/springcontainerms/base/config/service.yaml
+++ b/environments/example-es-truststore/services/springcontainerms/base/config/service.yaml
@@ -3,13 +3,15 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "springcontainerms-service"
+  name: "spring-container-ms"
   labels:
     chart: "springcontainerms-1.0.0"
+    app.kubernetes.io/part-of: refarch-kc
 spec:
   type: NodePort
   ports:
   - name: http
     port: 8080
+    nodePort: 31900
   selector:
     app: "springcontainerms-selector"

--- a/environments/example-es-truststore/services/springcontainerms/overlays/es-env.yaml
+++ b/environments/example-es-truststore/services/springcontainerms/overlays/es-env.yaml
@@ -13,11 +13,6 @@ spec:
               secretKeyRef:
                 name: "eventstreams-apikey"
                 key: binding
-          - name: POSTGRESQL_CA_PEM
-            valueFrom:
-              secretKeyRef:
-                name: "postgresql-ca-pem"
-                key: binding
           - name: TRUSTSTORE_ENABLED
             value: "true"
           - name: TRUSTSTORE_PWD

--- a/environments/example-es-truststore/services/springcontainerms/overlays/es-env.yaml
+++ b/environments/example-es-truststore/services/springcontainerms/overlays/es-env.yaml
@@ -1,13 +1,23 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: springcontainerms-deployment
+  name: spring-container-ms
 spec:
   template:
     spec:
       containers:
       - name: springcontainerms
         env:
+          - name: KAFKA_APIKEY
+            valueFrom:
+              secretKeyRef:
+                name: "eventstreams-apikey"
+                key: binding
+          - name: POSTGRESQL_CA_PEM
+            valueFrom:
+              secretKeyRef:
+                name: "postgresql-ca-pem"
+                key: binding
           - name: TRUSTSTORE_ENABLED
             value: "true"
           - name: TRUSTSTORE_PWD

--- a/environments/example-es-truststore/services/springcontainerms/overlays/es-volume-mount.yaml
+++ b/environments/example-es-truststore/services/springcontainerms/overlays/es-volume-mount.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: springcontainerms-deployment
+  name: spring-container-ms
 spec:
   template:
     spec:

--- a/environments/example-es-truststore/services/springcontainerms/overlays/es-volume.yaml
+++ b/environments/example-es-truststore/services/springcontainerms/overlays/es-volume.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: springcontainerms-deployment
+  name: spring-container-ms
 spec:
   template:
     spec:

--- a/environments/example-es-truststore/services/springcontainerms/overlays/postgres-ca-volume-mount.yaml
+++ b/environments/example-es-truststore/services/springcontainerms/overlays/postgres-ca-volume-mount.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: springcontainerms-deployment
+  name: spring-container-ms
 spec:
   template:
     spec:

--- a/environments/example-es-truststore/services/springcontainerms/overlays/postgres-ca-volume.yaml
+++ b/environments/example-es-truststore/services/springcontainerms/overlays/postgres-ca-volume.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: springcontainerms-deployment
+  name: spring-container-ms
 spec:
   template:
     spec:

--- a/environments/example-es-truststore/services/voyagesms/base/config/deployment.yaml
+++ b/environments/example-es-truststore/services/voyagesms/base/config/deployment.yaml
@@ -3,9 +3,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: "voyagesms-deployment"
+  name: "voyages-ms"
   labels:
     chart: 'voyagesms-1.0.0'
+    app.kubernetes.io/part-of: refarch-kc
 spec:
   replicas: 1
   strategy:
@@ -44,7 +45,7 @@ spec:
           - name: PORT
             value : "3000"
           - name: APPLICATION_NAME
-            value: "release-name"
+            value: "RELEASE-NAME"
           - name: KAFKA_BROKERS
             valueFrom:
               configMapKeyRef:
@@ -55,8 +56,3 @@ spec:
               configMapKeyRef:
                 name: "kafka-topics"
                 key: ordersTopic
-          - name: KAFKA_APIKEY
-            valueFrom:
-              secretKeyRef:
-                name: "eventstreams-apikey"
-                key: binding

--- a/environments/example-es-truststore/services/voyagesms/base/config/route.yaml
+++ b/environments/example-es-truststore/services/voyagesms/base/config/route.yaml
@@ -7,22 +7,12 @@ metadata:
   name: kcontainer-voyagesms
   labels:
     chart: 'voyagesms-1.0.0'
+    app.kubernetes.io/part-of: refarch-kc
 spec:
-  # Not a required attribute but ArgoCD fails sync without this field included in the YAML
-  # host: kcontainer-voyagesms-[project].[cluster-domain]
   path: /
   to:
     kind: Service
-    name: "voyagesms-service"
+    name: "voyages-ms"
     weight: 100
   port:
     targetPort: http
-# Not a required attribute but ArgoCD fails sync without this field included in the YAML
-status:
-  ingress:
-  - conditions:
-    - status: "True"
-      type: Admitted
-    # host: kcontainer-voyagesms-[project].[cluster-domain]
-    routerName: router
-    wildcardPolicy: None

--- a/environments/example-es-truststore/services/voyagesms/base/config/service.yaml
+++ b/environments/example-es-truststore/services/voyagesms/base/config/service.yaml
@@ -5,13 +5,15 @@ kind: Service
 metadata:
   annotations:
     prometheus.io/scrape: 'true'
-  name: "voyagesms-service"
+  name: "voyages-ms"
   labels:
     chart: "voyagesms-1.0.0"
+    app.kubernetes.io/part-of: refarch-kc
 spec:
   type: NodePort
   ports:
   - name: http
     port: 3000
+    nodePort: 31000
   selector:
     app: "voyagesms-selector"

--- a/environments/example-es-truststore/services/voyagesms/overlays/es-env.yaml
+++ b/environments/example-es-truststore/services/voyagesms/overlays/es-env.yaml
@@ -1,13 +1,18 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: voyagesms-deployment
+  name: voyages-ms
 spec:
   template:
     spec:
       containers:
       - name: voyagesms
         env:
+          - name: KAFKA_APIKEY
+            valueFrom:
+              secretKeyRef:
+                name: "eventstreams-apikey"
+                key: binding
           - name: CERTS_ENABLED
             value: "true"
           - name: CERTS_PATH

--- a/environments/example-es-truststore/services/voyagesms/overlays/es-volume-mount.yaml
+++ b/environments/example-es-truststore/services/voyagesms/overlays/es-volume-mount.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: voyagesms-deployment
+  name: voyages-ms
 spec:
   template:
     spec:

--- a/environments/example-es-truststore/services/voyagesms/overlays/es-volume.yaml
+++ b/environments/example-es-truststore/services/voyagesms/overlays/es-volume.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: voyagesms-deployment
+  name: voyages-ms
 spec:
   template:
     spec:


### PR DESCRIPTION
Update the starter-template branch to reflect recent updates to the refarch-kc microservice Helm charts (eg. https://github.com/ibm-cloud-architecture/refarch-kc-ui/pull/79).

I regenerated the deployment artifacts using `helm template`.  The approach I'm taking is for the base deployment to contain the minimal configuration required for each microservice, suitable for the `dev` environment, and then apply patches for other environments to add in the optional env vars / mounts (KAFKA_APIKEY, certificate volumes etc).

To this end, I've also extracted some of the optional parts of the `reefer-simulator` `app-deploy.yaml` into a set of patches.  This also lets us ensure that there are no configuration mismatches where an intended env var / mount is marked as optional, which would deploy successfully but could then misbehave at runtime.