### PR TITLE
scram credentials for ES v10

### DIFF
--- a/environments/example-credentials/env/base/kustomization.yaml
+++ b/environments/example-credentials/env/base/kustomization.yaml
@@ -8,9 +8,11 @@ resources:
   - ./bpm-configmap.yaml
 
 secretGenerator:
-  - name: eventstreams-apikey
+  - name: eventstreams-cred
+    literals:
+      - username=token
     files:
-      - ./credentials/eventstreams-apikey/binding
+      - ./credentials/eventstreams-cred/password
   - name: postgresql-url
     files:
       - ./credentials/postgresql-url/binding

--- a/environments/example-credentials/services/fleetms/overlays/appsody-env-patch.yaml
+++ b/environments/example-credentials/services/fleetms/overlays/appsody-env-patch.yaml
@@ -1,8 +1,16 @@
 - op: add
   path: "/spec/env/-"
   value:
-    name: KAFKA_APIKEY
+    name: KAFKA_USER
     valueFrom:
       secretKeyRef:
-        name: "eventstreams-apikey"
-        key: binding
+        name: "eventstreams-cred"
+        key: username
+- op: add
+  path: "/spec/env/-"
+  value:
+    name: KAFKA_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: "eventstreams-cred"
+        key: password

--- a/environments/example-credentials/services/kc-ui/overlays/appsody-env-patch.yaml
+++ b/environments/example-credentials/services/kc-ui/overlays/appsody-env-patch.yaml
@@ -1,8 +1,16 @@
 - op: add
   path: "/spec/env/-"
   value:
-    name: KAFKA_APIKEY
+    name: KAFKA_USER
     valueFrom:
       secretKeyRef:
-        name: "eventstreams-apikey"
-        key: binding
+        name: "eventstreams-cred"
+        key: username
+- op: add
+  path: "/spec/env/-"
+  value:
+    name: KAFKA_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: "eventstreams-cred"
+        key: password

--- a/environments/example-credentials/services/ordercommandms/overlays/appsody-env-patch.yaml
+++ b/environments/example-credentials/services/ordercommandms/overlays/appsody-env-patch.yaml
@@ -1,8 +1,16 @@
 - op: add
   path: "/spec/env/-"
   value:
-    name: KAFKA_APIKEY
+    name: KAFKA_USER
     valueFrom:
       secretKeyRef:
-        name: "eventstreams-apikey"
-        key: binding
+        name: "eventstreams-cred"
+        key: username
+- op: add
+  path: "/spec/env/-"
+  value:
+    name: KAFKA_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: "eventstreams-cred"
+        key: password

--- a/environments/example-credentials/services/orderqueryms/overlays/appsody-env-patch.yaml
+++ b/environments/example-credentials/services/orderqueryms/overlays/appsody-env-patch.yaml
@@ -1,8 +1,16 @@
 - op: add
   path: "/spec/env/-"
   value:
-    name: KAFKA_APIKEY
+    name: KAFKA_USER
     valueFrom:
       secretKeyRef:
-        name: "eventstreams-apikey"
-        key: binding
+        name: "eventstreams-cred"
+        key: username
+- op: add
+  path: "/spec/env/-"
+  value:
+    name: KAFKA_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: "eventstreams-cred"
+        key: password

--- a/environments/example-credentials/services/reefersimulator/overlays/appsody-env-patch.yaml
+++ b/environments/example-credentials/services/reefersimulator/overlays/appsody-env-patch.yaml
@@ -1,8 +1,16 @@
 - op: add
   path: "/spec/env/-"
   value:
-    name: KAFKA_APIKEY
+    name: KAFKA_USER
     valueFrom:
       secretKeyRef:
-        key: binding
-        name: eventstreams-apikey
+        name: "eventstreams-cred"
+        key: username
+- op: add
+  path: "/spec/env/-"
+  value:
+    name: KAFKA_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: "eventstreams-cred"
+        key: password

--- a/environments/example-credentials/services/scoringmp/base/config/deployment.yaml
+++ b/environments/example-credentials/services/scoringmp/base/config/deployment.yaml
@@ -68,7 +68,7 @@ spec:
           #############################
           ### Reactive Messaging topics
           #############################
-          - name: MP_MESSAGING_INCOMING_REEFERTELEMETRY_TOPIC
+          - name: MP_MESSAGING_INCOMING_REEFER_TELEMETRY_TOPIC
             valueFrom:
               configMapKeyRef:
                 name: "kafka-topics"

--- a/environments/example-credentials/services/scoringmp/overlays/bootstrap.properties
+++ b/environments/example-credentials/services/scoringmp/overlays/bootstrap.properties
@@ -6,7 +6,7 @@ mp.messaging.connector.liberty-kafka.security.protocol=SASL_SSL
 mp.messaging.connector.liberty-kafka.ssl.protocol=TLSv1.2
 mp.messaging.connector.liberty-kafka.sasl.mechanism=PLAIN
 # Make sure you set the username and API key at the end
-mp.messaging.connector.liberty-kafka.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="token" password="<API-KEY>";
+mp.messaging.connector.liberty-kafka.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="token" password="<KAFKA_PASSWORD>";
 
 # If connecting to Event Streams in OpenShift that requires certificates
 # Location for the truststore within the container

--- a/environments/example-credentials/services/springcontainerms/overlays/appsody-env-patch.yaml
+++ b/environments/example-credentials/services/springcontainerms/overlays/appsody-env-patch.yaml
@@ -1,8 +1,16 @@
 - op: add
   path: "/spec/env/-"
   value:
-    name: KAFKA_APIKEY
+    name: KAFKA_USER
     valueFrom:
       secretKeyRef:
-        name: "eventstreams-apikey"
-        key: binding
+        name: "eventstreams-cred"
+        key: username
+- op: add
+  path: "/spec/env/-"
+  value:
+    name: KAFKA_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: "eventstreams-cred"
+        key: password

--- a/environments/example-credentials/services/voyagesms/overlays/appsody-env-patch.yaml
+++ b/environments/example-credentials/services/voyagesms/overlays/appsody-env-patch.yaml
@@ -1,8 +1,16 @@
 - op: add
   path: "/spec/env/-"
   value:
-    name: KAFKA_APIKEY
+    name: KAFKA_USER
     valueFrom:
       secretKeyRef:
-        name: "eventstreams-apikey"
-        key: binding
+        name: "eventstreams-cred"
+        key: username
+- op: add
+  path: "/spec/env/-"
+  value:
+    name: KAFKA_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: "eventstreams-cred"
+        key: password

--- a/environments/example-es-truststore/env/base/kustomization.yaml
+++ b/environments/example-es-truststore/env/base/kustomization.yaml
@@ -8,14 +8,17 @@ resources:
   - ./bpm-configmap.yaml
 
 secretGenerator:
-  - name: eventstreams-apikey
+  - name: eventstreams-cred
     files:
-      - ./credentials/eventstreams-apikey/binding
-  - name: es-truststore-jks
+      - ./credentials/eventstreams-cred/username
+      - ./credentials/eventstreams-cred/password
+  - name: eventstreams-truststore
     files:
-      - ./credentials/eventstreams-truststore/es-cert.jks
+      - ./credentials/eventstreams-truststore/es-cert.p12
+  - name: eventstreams-truststore-pwd
+    files:
       - ./credentials/eventstreams-truststore/password
-  - name: es-ca-pemfile
+  - name: eventstreams-cert-pem
     files:
       - ./credentials/eventstreams-pem/es-cert.pem
   - name: postgresql-url

--- a/environments/example-es-truststore/services/fleetms/overlays/appsody-env-patch.yaml
+++ b/environments/example-es-truststore/services/fleetms/overlays/appsody-env-patch.yaml
@@ -1,11 +1,19 @@
 - op: add
   path: "/spec/env/-"
   value:
-    name: KAFKA_APIKEY
+    name: KAFKA_USER
     valueFrom:
       secretKeyRef:
-        name: "eventstreams-apikey"
-        key: binding
+        name: "eventstreams-cred"
+        key: username
+- op: add
+  path: "/spec/env/-"
+  value:
+    name: KAFKA_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: "eventstreams-cred"
+        key: password
 - op: add
   path: "/spec/env/-"
   value:
@@ -17,10 +25,10 @@
     name: TRUSTSTORE_PWD
     valueFrom:
       secretKeyRef:
-        name: es-truststore-jks
+        name: eventstreams-truststore-pwd
         key: password
 - op: add
   path: "/spec/env/-"
   value:
     name: TRUSTSTORE_PATH
-    value: /config/resources/security/es-ssl/es-cert.jks
+    value: /config/resources/security/es-ssl/es-cert.p12

--- a/environments/example-es-truststore/services/fleetms/overlays/appsody-volumes.yaml
+++ b/environments/example-es-truststore/services/fleetms/overlays/appsody-volumes.yaml
@@ -6,4 +6,4 @@ spec:
   volumes:
   - name: es-truststore-volume
     secret:
-      secretName: es-truststore-jks
+      secretName: eventstreams-truststore

--- a/environments/example-es-truststore/services/kc-ui/overlays/appsody-env-patch.yaml
+++ b/environments/example-es-truststore/services/kc-ui/overlays/appsody-env-patch.yaml
@@ -1,11 +1,19 @@
 - op: add
   path: "/spec/env/-"
   value:
-    name: KAFKA_APIKEY
+    name: KAFKA_USER
     valueFrom:
       secretKeyRef:
-        name: "eventstreams-apikey"
-        key: binding
+        name: "eventstreams-cred"
+        key: username
+- op: add
+  path: "/spec/env/-"
+  value:
+    name: KAFKA_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: "eventstreams-cred"
+        key: password
 - op: add
   path: "/spec/env/-"
   value:

--- a/environments/example-es-truststore/services/kc-ui/overlays/appsody-volumes.yaml
+++ b/environments/example-es-truststore/services/kc-ui/overlays/appsody-volumes.yaml
@@ -6,4 +6,4 @@ spec:
   volumes:
   - name: es-pem-volume
     secret:
-      secretName: es-ca-pemfile
+      secretName: eventstreams-cert-pem

--- a/environments/example-es-truststore/services/ordercommandms/overlays/appsody-env-patch.yaml
+++ b/environments/example-es-truststore/services/ordercommandms/overlays/appsody-env-patch.yaml
@@ -1,11 +1,19 @@
 - op: add
   path: "/spec/env/-"
   value:
-    name: KAFKA_APIKEY
+    name: KAFKA_USER
     valueFrom:
       secretKeyRef:
-        name: "eventstreams-apikey"
-        key: binding
+        name: "eventstreams-cred"
+        key: username
+- op: add
+  path: "/spec/env/-"
+  value:
+    name: KAFKA_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: "eventstreams-cred"
+        key: password
 - op: add
   path: "/spec/env/-"
   value:
@@ -17,10 +25,10 @@
     name: TRUSTSTORE_PWD
     valueFrom:
       secretKeyRef:
-        name: es-truststore-jks
+        name: eventstreams-truststore-pwd
         key: password
 - op: add
   path: "/spec/env/-"
   value:
     name: TRUSTSTORE_PATH
-    value: /config/resources/security/es-ssl/es-cert.jks
+    value: /config/resources/security/es-ssl/es-cert.p12

--- a/environments/example-es-truststore/services/ordercommandms/overlays/appsody-volumes.yaml
+++ b/environments/example-es-truststore/services/ordercommandms/overlays/appsody-volumes.yaml
@@ -6,4 +6,4 @@ spec:
   volumes:
   - name: es-truststore-volume
     secret:
-      secretName: es-truststore-jks
+      secretName: eventstreams-truststore

--- a/environments/example-es-truststore/services/orderqueryms/overlays/appsody-env-patch.yaml
+++ b/environments/example-es-truststore/services/orderqueryms/overlays/appsody-env-patch.yaml
@@ -1,11 +1,19 @@
 - op: add
   path: "/spec/env/-"
   value:
-    name: KAFKA_APIKEY
+    name: KAFKA_USER
     valueFrom:
       secretKeyRef:
-        name: "eventstreams-apikey"
-        key: binding
+        name: "eventstreams-cred"
+        key: username
+- op: add
+  path: "/spec/env/-"
+  value:
+    name: KAFKA_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: "eventstreams-cred"
+        key: password
 - op: add
   path: "/spec/env/-"
   value:
@@ -17,10 +25,10 @@
     name: TRUSTSTORE_PWD
     valueFrom:
       secretKeyRef:
-        name: es-truststore-jks
+        name: eventstreams-truststore-pwd
         key: password
 - op: add
   path: "/spec/env/-"
   value:
     name: TRUSTSTORE_PATH
-    value: /config/resources/security/es-ssl/es-cert.jks
+    value: /config/resources/security/es-ssl/es-cert.p12

--- a/environments/example-es-truststore/services/orderqueryms/overlays/appsody-volumes.yaml
+++ b/environments/example-es-truststore/services/orderqueryms/overlays/appsody-volumes.yaml
@@ -6,4 +6,4 @@ spec:
   volumes:
   - name: es-truststore-volume
     secret:
-      secretName: es-truststore-jks
+      secretName: eventstreams-truststore

--- a/environments/example-es-truststore/services/reefersimulator/overlays/appsody-env-patch.yaml
+++ b/environments/example-es-truststore/services/reefersimulator/overlays/appsody-env-patch.yaml
@@ -1,11 +1,19 @@
 - op: add
   path: "/spec/env/-"
   value:
-    name: KAFKA_APIKEY
+    name: KAFKA_USER
     valueFrom:
       secretKeyRef:
-        key: binding
-        name: eventstreams-apikey
+        name: "eventstreams-cred"
+        key: username
+- op: add
+  path: "/spec/env/-"
+  value:
+    name: KAFKA_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: "eventstreams-cred"
+        key: password
 - op: add
   path: "/spec/env/-"
   value:

--- a/environments/example-es-truststore/services/reefersimulator/overlays/appsody-volumes.yaml
+++ b/environments/example-es-truststore/services/reefersimulator/overlays/appsody-volumes.yaml
@@ -6,4 +6,4 @@ spec:
   volumes:
   - name: eventstreams-cert-pem
     secret:
-      secretName: es-ca-pemfile
+      secretName: eventstreams-cert-pem

--- a/environments/example-es-truststore/services/scoringmp/overlays/bootstrap.properties
+++ b/environments/example-es-truststore/services/scoringmp/overlays/bootstrap.properties
@@ -4,12 +4,13 @@ mp.messaging.connector.liberty-kafka.bootstrap.servers=broker-3-qnprtqnp7hnkssdz
 # If connecting to Event Streams on IBM Cloud or to any Kafka deployment with SSL security
 mp.messaging.connector.liberty-kafka.security.protocol=SASL_SSL
 mp.messaging.connector.liberty-kafka.ssl.protocol=TLSv1.2
-mp.messaging.connector.liberty-kafka.sasl.mechanism=PLAIN
+mp.messaging.connector.liberty-kafka.sasl.mechanism=SCRAM-SHA-512
+mp.messaging.connector.liberty-kafka.ssl.truststore.type=PKCS12
 # Make sure you set the username and API key at the end
-mp.messaging.connector.liberty-kafka.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="token" password="<API-KEY>";
+mp.messaging.connector.liberty-kafka.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="<KAFKA_USER>" password="<KAFKA_PASSWORD>";
 
 # If connecting to Event Streams in OpenShift that requires certificates
 # Location for the truststore within the container
-mp.messaging.connector.liberty-kafka.ssl.truststore.location=/config/resources/security/es-cert.jks
+mp.messaging.connector.liberty-kafka.ssl.truststore.location=/config/resources/security/es-cert.p12
 # Password for the truststore
-mp.messaging.connector.liberty-kafka.ssl.truststore.password=password
+mp.messaging.connector.liberty-kafka.ssl.truststore.password=<EVENTSTREAMS_TRUSTSTORE_PWD>

--- a/environments/example-es-truststore/services/springcontainerms/overlays/appsody-env-patch.yaml
+++ b/environments/example-es-truststore/services/springcontainerms/overlays/appsody-env-patch.yaml
@@ -1,11 +1,19 @@
 - op: add
   path: "/spec/env/-"
   value:
-    name: KAFKA_APIKEY
+    name: KAFKA_USER
     valueFrom:
       secretKeyRef:
-        name: "eventstreams-apikey"
-        key: binding
+        name: "eventstreams-cred"
+        key: username
+- op: add
+  path: "/spec/env/-"
+  value:
+    name: KAFKA_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: "eventstreams-cred"
+        key: password
 - op: add
   path: "/spec/env/-"
   value:
@@ -17,10 +25,10 @@
     name: TRUSTSTORE_PWD
     valueFrom:
       secretKeyRef:
-        name: es-truststore-jks
+        name: eventstreams-truststore-pwd
         key: password
 - op: add
   path: "/spec/env/-"
   value:
     name: TRUSTSTORE_PATH
-    value: /config/resources/security/es-ssl/es-cert.jks
+    value: /config/resources/security/es-ssl/es-cert.p12

--- a/environments/example-es-truststore/services/springcontainerms/overlays/appsody-volumes.yaml
+++ b/environments/example-es-truststore/services/springcontainerms/overlays/appsody-volumes.yaml
@@ -6,7 +6,7 @@ spec:
   volumes:
   - name: es-truststore-volume
     secret:
-      secretName: es-truststore-jks
+      secretName: eventstreams-truststore
   - name: postgresql-ca-volume
     secret:
       secretName: postgresql-ca-pem

--- a/environments/example-es-truststore/services/voyagesms/overlays/appsody-env-patch.yaml
+++ b/environments/example-es-truststore/services/voyagesms/overlays/appsody-env-patch.yaml
@@ -1,11 +1,19 @@
 - op: add
   path: "/spec/env/-"
   value:
-    name: KAFKA_APIKEY
+    name: KAFKA_USER
     valueFrom:
       secretKeyRef:
-        name: "eventstreams-apikey"
-        key: binding
+        name: "eventstreams-cred"
+        key: username
+- op: add
+  path: "/spec/env/-"
+  value:
+    name: KAFKA_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: "eventstreams-cred"
+        key: password
 - op: add
   path: "/spec/env/-"
   value:

--- a/environments/example-es-truststore/services/voyagesms/overlays/appsody-volumes.yaml
+++ b/environments/example-es-truststore/services/voyagesms/overlays/appsody-volumes.yaml
@@ -6,4 +6,4 @@ spec:
   volumes:
   - name: es-pem-volume
     secret:
-      secretName: es-ca-pemfile
+      secretName: eventstreams-cert-pem


### PR DESCRIPTION
I updated the `example-credentials` and `example-es-truststore` gitops environments based on the conversation we had yesterday. The main changes are:

For both environments:
-----------------------
* `KAFKA_APIKEY` is now divided into `KAFKA_USER` and `KAFKA_PASSWORD` to allow for SCRAM credentials

For truststore environment:
---------------------------

* Name for the truststore and pem certificates secrets has changed to `eventstreams-truststore` and `eventstreams-cert-pem` respectively 
* truststore extension has changed to `.p12`
* Name for the truststore's password secret has changed to `eventstreams-truststore-pwd`

**TBD:**
1. Cleanup of the `environments/example-es-truststore/env/base/kustomization.yaml` based on the changes above and what yesterday was decided about removing the secretGenerators and namespace (did not quite catch this one. This is why is in this section.  :( Sorry)
2. Any documentation update based on the above (I believe that is the gitops section we have at https://ibm-cloud-architecture.github.io/refarch-kc/infrastructure/gitops/ but since it is not yet created I just point this out)

This is one of the changes suggested in ibm-cloud-architecture/refarch-kc#119